### PR TITLE
Fix unhandled error on charts page after app update

### DIFF
--- a/Features/Charts/UI/Pages/Charts.razor
+++ b/Features/Charts/UI/Pages/Charts.razor
@@ -254,24 +254,38 @@
 
         if (firstRender && AirportId is null)
         {
-            var savedStateTask = await ProtectedLocalStore.GetAsync<ChartState>(ChartStateSessionStorageKey);
-            if (savedStateTask is { Success: true, Value: not null })
+            try
             {
-                await UpdateCharts(savedStateTask.Value.AirportId);
-                _displayedChart = savedStateTask.Value.Chart;
-                _displayedChartPage = savedStateTask.Value.Page;
-                stateUpdated = true;
+                var savedStateTask = await ProtectedLocalStore.GetAsync<ChartState>(ChartStateSessionStorageKey);
+                if (savedStateTask is { Success: true, Value: not null })
+                {
+                    await UpdateCharts(savedStateTask.Value.AirportId);
+                    _displayedChart = savedStateTask.Value.Chart;
+                    _displayedChartPage = savedStateTask.Value.Page;
+                    stateUpdated = true;
+                }
+            }
+            catch
+            {
+                // Local storage data may be unreadable after an app update
             }
         }
 
         if (firstRender)
         {
-            var savedCustomAirportsTask = await ProtectedLocalStore.GetAsync<List<SavedAirport>>(CustomAirportsSessionStorageKey);
-            if (savedCustomAirportsTask is { Success: true, Value: not null })
+            try
             {
-                var customAirports = savedCustomAirportsTask.Value.Select(a => new Airport(a.Id, AirportType.Other, a.Guid));
-                _airports.AddRange(customAirports);
-                stateUpdated = true;
+                var savedCustomAirportsTask = await ProtectedLocalStore.GetAsync<List<SavedAirport>>(CustomAirportsSessionStorageKey);
+                if (savedCustomAirportsTask is { Success: true, Value: not null })
+                {
+                    var customAirports = savedCustomAirportsTask.Value.Select(a => new Airport(a.Id, AirportType.Other, a.Guid));
+                    _airports.AddRange(customAirports);
+                    stateUpdated = true;
+                }
+            }
+            catch
+            {
+                // Local storage data may be unreadable after an app update
             }
         }
 

--- a/Features/Routes/UI/Pages/Routes.razor
+++ b/Features/Routes/UI/Pages/Routes.razor
@@ -170,12 +170,19 @@
     {
         if (firstRender)
         {
-            var savedStateTask = await ProtectedSessionStore.GetAsync<SavedAirportPairRoutes>(SavedAirportPairRoutesStorageKey);
-            if (savedStateTask.Success)
+            try
             {
-                _routeForm.DepartureId = savedStateTask.Value.DepartureId;
-                _routeForm.ArrivalId = savedStateTask.Value.ArrivalId;
-                await RouteSubmit();
+                var savedStateTask = await ProtectedSessionStore.GetAsync<SavedAirportPairRoutes>(SavedAirportPairRoutesStorageKey);
+                if (savedStateTask.Success)
+                {
+                    _routeForm.DepartureId = savedStateTask.Value.DepartureId;
+                    _routeForm.ArrivalId = savedStateTask.Value.ArrivalId;
+                    await RouteSubmit();
+                }
+            }
+            catch
+            {
+                // Session storage data may be unreadable after an app update
             }
 
             StateHasChanged();

--- a/Features/Scratchpads/UI/Pages/Scratchpads.razor
+++ b/Features/Scratchpads/UI/Pages/Scratchpads.razor
@@ -41,16 +41,23 @@
     {
         if (firstRender)
         {
-            var savedStateTask = await ProtectedSessionStore.GetAsync<string>("scratchpadsSelectedFacilityId");
-            if (savedStateTask is { Success: true, Value: not null })
+            try
             {
-                if (ScratchpadRepository.TryGetValue(savedStateTask.Value, out var foundScratchpads))
+                var savedStateTask = await ProtectedSessionStore.GetAsync<string>("scratchpadsSelectedFacilityId");
+                if (savedStateTask is { Success: true, Value: not null })
                 {
-                    _selectedFacilityId = savedStateTask.Value;
-                    _selectedScratchpads = foundScratchpads!;
-                }
+                    if (ScratchpadRepository.TryGetValue(savedStateTask.Value, out var foundScratchpads))
+                    {
+                        _selectedFacilityId = savedStateTask.Value;
+                        _selectedScratchpads = foundScratchpads!;
+                    }
 
-                StateHasChanged();
+                    StateHasChanged();
+                }
+            }
+            catch
+            {
+                // Session storage data may be unreadable after an app update
             }
 
             await Js.InvokeVoidAsync("SetFocusToElement", _dropdown);

--- a/Features/VnasData/UI/Pages/VideoMaps.razor
+++ b/Features/VnasData/UI/Pages/VideoMaps.razor
@@ -55,17 +55,24 @@
     {
         if (firstRender)
         {
-            var savedStateTask = await ProtectedSessionStore.GetAsync<string>("videomapsSelectedFacilityId");
-            if (savedStateTask is { Success: true, Value: not null })
+            try
             {
-                var facility = _facilities.FirstOrDefault(f => f.Facility.Id == savedStateTask.Value);
-                if (facility is not null)
+                var savedStateTask = await ProtectedSessionStore.GetAsync<string>("videomapsSelectedFacilityId");
+                if (savedStateTask is { Success: true, Value: not null })
                 {
-                    _selectedFacilityId = savedStateTask.Value;
-                    _selectedFacility = facility;
-                }
+                    var facility = _facilities.FirstOrDefault(f => f.Facility.Id == savedStateTask.Value);
+                    if (facility is not null)
+                    {
+                        _selectedFacilityId = savedStateTask.Value;
+                        _selectedFacility = facility;
+                    }
 
-                StateHasChanged();
+                    StateHasChanged();
+                }
+            }
+            catch
+            {
+                // Session storage data may be unreadable after an app update
             }
 
             await Js.InvokeVoidAsync("SetFocusToElement", _input);


### PR DESCRIPTION
## Summary
- Wrap all `ProtectedLocalStorage`/`ProtectedSessionStore.GetAsync` calls in try-catch blocks across Charts, Routes, Scratchpads, and VideoMaps pages
- When stored state is unreadable (e.g. after a deployment changes data protection keys), pages now fall back to default state instead of showing an unhandled error banner
- Matches the defensive pattern already used in Procedures.razor

Fixes #31

## Test plan
- [ ] Deploy an update and verify the charts page loads without error (no need to clear `chartState` from localStorage)
- [ ] Verify other pages (Routes, VideoMaps, Scratchpads) also handle stale storage gracefully
- [ ] Confirm saved state still restores correctly under normal operation (no app update between visits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)