### PR TITLE
Fix PDF rotation detection for multi-page charts

### DIFF
--- a/Features/Charts/Services/ChartPdfProcessingService.cs
+++ b/Features/Charts/Services/ChartPdfProcessingService.cs
@@ -55,7 +55,7 @@ public class ChartPdfProcessingService(
                     if (rotation != 0)
                     {
                         importedPage.Rotate =
-                            (importedPage.Rotate - rotation + 360) % 360;
+                            (importedPage.Rotate + rotation + 360) % 360;
                     }
                 }
             }

--- a/Features/Charts/Services/PdfRotationDetector.cs
+++ b/Features/Charts/Services/PdfRotationDetector.cs
@@ -1,8 +1,11 @@
 using UglyToad.PdfPig;
-using UglyToad.PdfPig.Content;
 
 namespace ZoaReference.Features.Charts.Services;
 
+/// <summary>
+/// Detects PDF text rotation by analyzing baseline angles of individual letters,
+/// matching the CLI's atan2-based transformation matrix approach.
+/// </summary>
 public class PdfRotationDetector
 {
     public int DetectRotation(byte[] pdfBytes)
@@ -12,7 +15,7 @@ public class PdfRotationDetector
             using var stream = new MemoryStream(pdfBytes);
             using var document = PdfDocument.Open(stream);
 
-            var orientationCounts = new Dictionary<TextOrientation, int>();
+            var angleCounts = new Dictionary<int, int>();
 
             foreach (var page in document.GetPages())
             {
@@ -23,32 +26,60 @@ public class PdfRotationDetector
                         continue;
                     }
 
-                    orientationCounts.TryGetValue(letter.TextOrientation, out var count);
-                    orientationCounts[letter.TextOrientation] = count + 1;
+                    var dx = letter.EndBaseLine.X - letter.StartBaseLine.X;
+                    var dy = letter.EndBaseLine.Y - letter.StartBaseLine.Y;
+
+                    if (Math.Abs(dx) < 0.001 && Math.Abs(dy) < 0.001)
+                    {
+                        continue;
+                    }
+
+                    var rawAngle = Math.Atan2(dy, dx) * 180.0 / Math.PI;
+                    var rounded = (int)(Math.Round(rawAngle / 10.0) * 10);
+                    angleCounts.TryGetValue(rounded, out var count);
+                    angleCounts[rounded] = count + 1;
                 }
             }
 
-            if (orientationCounts.Count == 0)
+            if (angleCounts.Count == 0)
             {
                 return 0;
             }
 
-            var dominant = orientationCounts
-                .OrderByDescending(kv => kv.Value)
-                .First()
-                .Key;
+            var upright = CountBucket(angleCounts, [-10, 0, 10]);
+            var rotated90 = CountBucket(angleCounts, [80, 90, 100]);
+            var rotatedNeg90 = CountBucket(angleCounts, [-80, -90, -100]);
 
-            return dominant switch
+            if (rotated90 > upright && rotated90 >= rotatedNeg90)
             {
-                TextOrientation.Rotate90 => 90,
-                TextOrientation.Rotate270 => -90,
-                TextOrientation.Rotate180 => 180,
-                _ => 0
-            };
+                return 90;
+            }
+
+            if (rotatedNeg90 > upright && rotatedNeg90 > rotated90)
+            {
+                return -90;
+            }
+
+            return 0;
         }
         catch (Exception)
         {
             return 0;
         }
+    }
+
+    private static int CountBucket(
+        Dictionary<int, int> counts, int[] angles)
+    {
+        var total = 0;
+        foreach (var angle in angles)
+        {
+            if (counts.TryGetValue(angle, out var count))
+            {
+                total += count;
+            }
+        }
+
+        return total;
     }
 }


### PR DESCRIPTION
## Summary
- Rewrote `PdfRotationDetector` to compute text angles from letter baseline vectors using `atan2` with ±10° tolerance buckets, replacing PdfPig's `TextOrientation` enum which failed to detect rotation on some pages (e.g. OAK OAKES page 2)
- Fixed rotation application to add the correction angle instead of subtracting it

## Test plan
- [ ] Verify OAK OAKES displays both pages correctly rotated
- [ ] Verify other multi-page charts (SIDs/STARs) still rotate correctly
- [ ] Verify single-page charts with rotation still display correctly
- [ ] Verify charts that need no rotation are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)