### PR TITLE
fix: Ctrl+L clears screen instead of printing ghost prompts

### DIFF
--- a/Features/Terminal/UI/Pages/Terminal.razor
+++ b/Features/Terminal/UI/Pages/Terminal.razor
@@ -51,7 +51,7 @@
         {
             _dotnetRef = DotNetObjectReference.Create(this);
             _module = await JS.InvokeAsync<IJSObjectReference>(
-                "import", "/scripts/terminal.js?v=3");
+                "import", "/scripts/terminal.js?v=4");
             await _module.InvokeVoidAsync("initialize", _terminalContainer, _dotnetRef);
             return;
         }

--- a/wwwroot/scripts/terminal.js
+++ b/wwwroot/scripts/terminal.js
@@ -222,9 +222,13 @@ async function onData(data) {
 
     // --- Ctrl+L ---
     if (data === "\x0c") {
-        terminal.clear();
+        terminal.write("\x1b[2J\x1b[H");
         writePrompt();
         terminal.write(lineBuffer);
+        const diff = lineBuffer.length - cursorPos;
+        if (diff > 0) {
+            terminal.write(`\x1b[${diff}D`);
+        }
         return;
     }
 


### PR DESCRIPTION
## Summary

- Replace `terminal.clear()` with ANSI escape sequences (`\x1b[2J\x1b[H`) for Ctrl+L handling in the terminal
- `terminal.clear()` only clears xterm.js scrollback, not the visible viewport, causing repeated ghost prompts and text overwriting
- Also restores correct cursor position when there's partially-typed input

Closes #58

## Test plan

- [ ] Open `/terminal`, type some commands, press Ctrl+L — screen should clear with a fresh prompt at the top
- [ ] Type partial input, press Ctrl+L — screen clears and partial input is preserved with correct cursor position
- [ ] Verify typing `clear` command still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)