### PR TITLE
Fix terminal input line flickering

### DIFF
--- a/Features/Terminal/UI/Pages/Terminal.razor
+++ b/Features/Terminal/UI/Pages/Terminal.razor
@@ -51,7 +51,7 @@
         {
             _dotnetRef = DotNetObjectReference.Create(this);
             _module = await JS.InvokeAsync<IJSObjectReference>(
-                "import", "/scripts/terminal.js?v=3");
+                "import", "/scripts/terminal.js?v=4");
             await _module.InvokeVoidAsync("initialize", _terminalContainer, _dotnetRef);
             return;
         }

--- a/wwwroot/scripts/terminal.js
+++ b/wwwroot/scripts/terminal.js
@@ -11,6 +11,7 @@ let historyIndex = -1;
 let tempLine = "";
 let pendingSelectionCount = 0; // When >0, single digit keypress triggers selection
 
+
 const PROMPT = "\x1b[38;5;208mzoa\x1b[0m \x1b[36m❯\x1b[0m ";
 const PROMPT_LEN = 6; // "zoa ❯ " visible characters
 
@@ -92,6 +93,7 @@ export async function initialize(containerEl, ref) {
     terminal.open(containerEl);
     fitAddon.fit();
 
+
     // Welcome banner
     terminal.writeln("\x1b[38;5;208m" +
         "  ______  ___    _    ___      __                          \r\n" +
@@ -117,17 +119,14 @@ function writePrompt() {
     terminal.write(PROMPT);
 }
 
-function clearLine() {
-    terminal.write("\r" + PROMPT + " ".repeat(lineBuffer.length + 2) + "\r" + PROMPT);
-}
-
 function redrawLine() {
-    clearLine();
-    terminal.write(lineBuffer);
+    let output = "\x1b[?25l\r" + PROMPT + lineBuffer + "\x1b[K";
     const diff = lineBuffer.length - cursorPos;
     if (diff > 0) {
-        terminal.write(`\x1b[${diff}D`);
+        output += `\x1b[${diff}D`;
     }
+    output += "\x1b[?25h";
+    terminal.write(output);
 }
 
 async function submitInput(input) {
@@ -364,13 +363,21 @@ async function onData(data) {
     if (data.startsWith("\x1b")) return;
 
     // Regular character input
+    const atEnd = cursorPos === lineBuffer.length;
+    let printable = "";
     for (const ch of data) {
         if (ch >= " ") {
             lineBuffer = lineBuffer.slice(0, cursorPos) + ch + lineBuffer.slice(cursorPos);
             cursorPos++;
+            printable += ch;
         }
     }
-    redrawLine();
+    if (printable.length === 0) return;
+    if (atEnd) {
+        terminal.write(printable);
+    } else {
+        redrawLine();
+    }
 }
 
 async function handleTabCompletion() {


### PR DESCRIPTION
## Summary
- Rewrote `redrawLine()` to use a single `terminal.write()` call with cursor hidden (`\x1b[?25l`/`\x1b[?25h`) and `\x1b[K` erase-to-EOL, replacing the multi-write space-padding approach
- Added fast path for typing at end of line — writes characters directly without a full redraw
- Removed now-unused `clearLine()` function
- Bumped JS module cache-buster version

## Test plan
- [ ] Type characters rapidly — no flicker or cursor jumping
- [ ] Type with cursor in the middle of text (arrow left, then type) — text redraws correctly
- [ ] Backspace, Delete, Ctrl+W, Ctrl+Delete — all still work
- [ ] History navigation (up/down arrows) — still works
- [ ] Tab completion — still works
- [ ] Ctrl+L (clear screen) — still works
- [ ] Paste via Ctrl+V and right-click — still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)