### PR TITLE
fix: SOP multi-token queries matching wrong procedure

### DIFF
--- a/Features/Docs/Services/ProcedureMatcher.cs
+++ b/Features/Docs/Services/ProcedureMatcher.cs
@@ -72,11 +72,11 @@ public partial class ProcedureMatcher(ProcedureSearchConfig config)
 
         var bestMatch = matches[0];
 
-        if (bestMatch.Score >= 1.0)
-        {
-            return (bestMatch.Document, matches);
-        }
-
+        // For multi-token queries, prefer the match containing ALL original tokens.
+        // This must run before the score-based shortcut because alias expansion can
+        // inflate scores for partial matches (e.g., "NCT ZOA" expands ZOA →
+        // "OAKLAND CENTER" which scores 1.0 against "Oakland Center SOP", but the
+        // user wanted the LOA that contains both NCT and ZOA).
         if (queryTokens.Count > 1)
         {
             var fullMatches = matches.Where(m =>


### PR DESCRIPTION
## Summary
- Remove the `score >= 1.0` early return in `ProcedureMatcher.FindByName` that bypassed the all-tokens check
- Alias expansion (e.g., ZOA → "OAKLAND CENTER") could inflate scores for partial matches, causing multi-token queries like "nct zoa" to match "Oakland Center SOP" instead of the NCT-ZOA LOA
- Port of leftos/zoa-reference-cli@c77e3d0

## Test plan
- [ ] Search for "nct zoa" in terminal and verify it returns the NCT-ZOA LOA, not Oakland Center SOP
- [ ] Search for single-token procedure names and verify they still resolve correctly
- [ ] Search for other multi-token queries to verify no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)