### PR TITLE
fix: prevent false rotation on charts with few text characters

### DIFF
--- a/Features/Charts/Services/PdfRotationDetector.cs
+++ b/Features/Charts/Services/PdfRotationDetector.cs
@@ -8,6 +8,8 @@ namespace ZoaReference.Features.Charts.Services;
 /// </summary>
 public class PdfRotationDetector
 {
+    private const int MinLettersForRotation = 100;
+
     public int DetectRotation(byte[] pdfBytes)
     {
         try
@@ -41,7 +43,8 @@ public class PdfRotationDetector
                 }
             }
 
-            if (angleCounts.Count == 0)
+            var totalLetters = angleCounts.Values.Sum();
+            if (totalLetters < MinLettersForRotation)
             {
                 return 0;
             }
@@ -50,12 +53,14 @@ public class PdfRotationDetector
             var rotated90 = CountBucket(angleCounts, [80, 90, 100]);
             var rotatedNeg90 = CountBucket(angleCounts, [-80, -90, -100]);
 
-            if (rotated90 > upright && rotated90 >= rotatedNeg90)
+            if (rotated90 > upright && rotated90 >= rotatedNeg90
+                && rotated90 > totalLetters / 2)
             {
                 return 90;
             }
 
-            if (rotatedNeg90 > upright && rotatedNeg90 > rotated90)
+            if (rotatedNeg90 > upright && rotatedNeg90 > rotated90
+                && rotatedNeg90 > totalLetters / 2)
             {
                 return -90;
             }


### PR DESCRIPTION
## Summary

- NFL SID charts (FALLON ONE, YERIN EIGHT) have very few extractable text characters (~50 compass/heading labels split evenly between ±90°), causing the rotation detector to incorrectly apply 90° rotation to portrait charts
- Added a minimum letter threshold (100) and majority requirement (>50% of letters) to `PdfRotationDetector` so rotation is only applied when there's strong statistical evidence

## Diagnostics

Tested against actual FAA chart PDFs:

| Chart | Letters | Old result | New result |
|-------|---------|------------|------------|
| FALLON ONE (NFL SID) | 50 | 90° (wrong) | 0° (correct) |
| YERIN EIGHT (NFL SID) | 50 | 90° (wrong) | 0° (correct) |
| CIITY THREE (SFO SID) | 1407 | 90° (correct) | 90° (correct) |

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)