### PR TITLE
dep: replace PdfSharpCore with official PDFsharp 6.2.4

### DIFF
--- a/Features/Charts/Services/ChartPdfProcessingService.cs
+++ b/Features/Charts/Services/ChartPdfProcessingService.cs
@@ -1,8 +1,8 @@
 using System.Security.Cryptography;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
-using PdfSharpCore.Pdf;
-using PdfSharpCore.Pdf.IO;
+using PdfSharp.Pdf;
+using PdfSharp.Pdf.IO;
 using Sentry;
 using ZoaReference.Features.Charts.Models;
 

--- a/ZoaReference.csproj
+++ b/ZoaReference.csproj
@@ -22,7 +22,7 @@
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
         <PackageReference Include="Microsoft.Extensions.Hosting.Systemd" Version="8.0.0" />
         <PackageReference Include="PdfPig" Version="0.1.13" />
-        <PackageReference Include="PdfSharpCore" Version="1.3.67" />
+        <PackageReference Include="PDFsharp" Version="6.2.4" />
         <PackageReference Include="Sentry.AspNetCore" Version="5.11.2" />
     </ItemGroup>
 


### PR DESCRIPTION
## Summary
- Replace unmaintained `PdfSharpCore` 1.3.67 with the official `PDFsharp` 6.2.4 package
- Eliminates transitive dependency on `SixLabors.ImageSharp` 1.0.4, which has 7 known vulnerabilities (3 high, 4 moderate)
- No functional changes — same API surface, just updated namespace imports

## Test plan
- [ ] Verify the app builds successfully
- [ ] Test chart PDF viewing (multi-page merge + rotation correction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)