### PR TITLE
fix: small terminal command parity fixes vs standalone CLI

### DIFF
--- a/Features/Terminal/Commands/ApproachesCommand.cs
+++ b/Features/Terminal/Commands/ApproachesCommand.cs
@@ -53,12 +53,14 @@ public class ApproachesCommand(StarApproachConnectionService connectionService, 
             headerLabel = $"Fix {query}";
         }
 
-        // Filter by runways if specified (partial match: "17" matches "17", "17L", "17R")
+        // Filter by runways if specified. RunwayFormat.FilterMatches strips
+        // leading zeros on both sides so "4" catches "04L" / "04R" as well as
+        // "4L" / "4R", and "17" still catches "17", "17L", "17R".
         if (runwayFilters.Count > 0)
         {
             connections = connections
                 .Where(c => c.Runway is not null &&
-                    runwayFilters.Any(f => c.Runway.StartsWith(f, StringComparison.OrdinalIgnoreCase)))
+                    runwayFilters.Any(f => RunwayFormat.FilterMatches(f, c.Runway)))
                 .ToList();
         }
 

--- a/Features/Terminal/Commands/ChartCommand.cs
+++ b/Features/Terminal/Commands/ChartCommand.cs
@@ -15,6 +15,14 @@ public partial class ChartCommand(AviationApiChartService chartService, AirportR
         ["5"] = "FIVE", ["6"] = "SIX", ["7"] = "SEVEN", ["8"] = "EIGHT", ["9"] = "NINE",
     };
 
+    // Aliases applied to the whole filter string (e.g. "TAXI" → "AIRPORT DIAGRAM")
+    // so users can type shorthand chart names. Mirrors Python charts.py:_normalize_chart_name.
+    private static readonly Dictionary<string, string> ChartNameAliases = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["TAXI"] = "AIRPORT DIAGRAM",
+        ["DVA"] = "DIVERSE VECTOR AREA",
+    };
+
     public string Name => "chart";
     public string[] Aliases => ["charts"];
     public string Summary => "Look up airport charts";
@@ -44,9 +52,15 @@ public partial class ChartCommand(AviationApiChartService chartService, AirportR
         // Filter by chart code if provided
         if (args.Positional.Length >= 2)
         {
-            // Normalize single-digit runway numbers (e.g. "RNAV 4L" → "RNAV 04L")
+            var rawFilter = string.Join(" ", args.Positional[1..]);
+            // Expand whole-string aliases (TAXI → AIRPORT DIAGRAM, DVA → DIVERSE
+            // VECTOR AREA) before normalizing runways so shorthand queries work.
+            var aliased = ChartNameAliases.TryGetValue(rawFilter.Trim(), out var substitution)
+                ? substitution
+                : rawFilter;
+            // Pad single-digit runway numbers (e.g. "RNAV 4L" → "RNAV 04L")
             // so users don't need the leading zero for IAPs.
-            var filter = NormalizeRunwayNumbers(string.Join(" ", args.Positional[1..]));
+            var filter = RunwayFormat.PadSingleDigit(aliased);
             var codeFilter = args.Positional[1].ToUpperInvariant();
 
             // Try chart code first (DP, STAR, IAP, APD, etc.)
@@ -181,17 +195,6 @@ public partial class ChartCommand(AviationApiChartService chartService, AirportR
 
     [GeneratedRegex(@"[A-Z]+|\d+")]
     private static partial Regex TokenizeRegex();
-
-    /// <summary>
-    /// Pads single-digit runway numbers with a leading zero so queries like
-    /// "RNAV 4L" match chart names like "RNAV (GPS) RWY 04L". Leaves two-digit
-    /// runways ("28R") and non-runway digits untouched.
-    /// </summary>
-    private static string NormalizeRunwayNumbers(string input) =>
-        SingleDigitRunwayRegex().Replace(input, "0$1");
-
-    [GeneratedRegex(@"\b(\d[LRC]?)\b", RegexOptions.IgnoreCase)]
-    private static partial Regex SingleDigitRunwayRegex();
 
     public IEnumerable<string> GetCompletions(string partial, int argIndex)
     {

--- a/Features/Terminal/Commands/NavaidCommand.cs
+++ b/Features/Terminal/Commands/NavaidCommand.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using ZoaReference.Features.Nasr.Models;
 using ZoaReference.Features.Nasr.Services;
 using ZoaReference.Features.Terminal.Services;
 
@@ -10,8 +11,9 @@ public class NavaidCommand(NasrDataService nasrDataService) : ITerminalCommand
     public string[] Aliases => ["nav"];
     public string Summary => "Search navaids by ID, name, or type";
     public string Usage => "navaid <query>\n" +
-                           "    navaid SJC     — Search by navaid ID\n" +
-                           "    navaid VORTAC  — Search by type";
+                           "    navaid SJC           — Search by navaid ID\n" +
+                           "    navaid VORTAC        — Search by type\n" +
+                           "    navaid SFO OAK RNO   — Look up multiple navaids at once";
 
     public async Task<CommandResult> ExecuteAsync(CommandArgs args)
     {
@@ -20,7 +22,14 @@ public class NavaidCommand(NasrDataService nasrDataService) : ITerminalCommand
             return CommandResult.FromError("Usage: navaid <query>");
         }
 
-        var query = string.Join(" ", args.Positional);
+        // Multiple positional args → treat each as its own lookup (matches the CLI),
+        // e.g. `navaid SFO OAK RNO`. A multi-word name still works with quotes.
+        if (args.Positional.Length > 1)
+        {
+            return await LookupMultiple(args.Positional);
+        }
+
+        var query = args.Positional[0];
         var results = await nasrDataService.SearchNavaids(query);
 
         if (results.Count == 0)
@@ -28,6 +37,51 @@ public class NavaidCommand(NasrDataService nasrDataService) : ITerminalCommand
             return CommandResult.FromError($"No navaids found matching '{query}'");
         }
 
+        return CommandResult.FromText(FormatResultsTable(query, results));
+    }
+
+    private async Task<CommandResult> LookupMultiple(string[] queries)
+    {
+        var sb = new StringBuilder();
+        var notFound = new List<string>();
+        var anyFound = false;
+
+        foreach (var query in queries)
+        {
+            var results = await nasrDataService.SearchNavaids(query);
+
+            if (results.Count == 0)
+            {
+                notFound.Add(query);
+                continue;
+            }
+
+            if (anyFound)
+            {
+                sb.AppendLine();
+            }
+            sb.Append(FormatResultsTable(query, results));
+            anyFound = true;
+        }
+
+        if (!anyFound)
+        {
+            return CommandResult.FromError(
+                $"No navaids found matching: {string.Join(", ", notFound)}");
+        }
+
+        if (notFound.Count > 0)
+        {
+            sb.AppendLine();
+            sb.AppendLine(TextFormatter.Colorize(
+                $"  No matches for: {string.Join(", ", notFound)}", AnsiColor.Gray));
+        }
+
+        return CommandResult.FromText(sb.ToString());
+    }
+
+    private static string FormatResultsTable(string query, IReadOnlyList<NavaidInfo> results)
+    {
         var displayed = results.Take(30).ToList();
         var sb = new StringBuilder();
         var widths = new[] { 8, 24, 12, 10, 24 };
@@ -47,7 +101,7 @@ public class NavaidCommand(NasrDataService nasrDataService) : ITerminalCommand
             sb.AppendLine($"  {TextFormatter.Colorize($"... and {results.Count - 30} more", AnsiColor.Gray)}");
         }
 
-        return CommandResult.FromText(sb.ToString());
+        return sb.ToString();
     }
 
     private static string Truncate(string text, int maxLen) =>

--- a/Features/Terminal/Services/RunwayFormat.cs
+++ b/Features/Terminal/Services/RunwayFormat.cs
@@ -1,0 +1,41 @@
+using System.Text.RegularExpressions;
+
+namespace ZoaReference.Features.Terminal.Services;
+
+/// <summary>
+/// Shared helpers for handling runway identifiers where the user may type
+/// a single digit (<c>4L</c>, <c>4</c>) but the data stores the zero-padded
+/// form (<c>04L</c>), or vice versa. Different commands need different
+/// directions of the same fix, so the logic lives here.
+/// </summary>
+public static partial class RunwayFormat
+{
+    /// <summary>
+    /// Pads single-digit runway numbers with a leading zero so queries like
+    /// <c>"RNAV 4L"</c> match chart names like <c>"RNAV (GPS) RWY 04L"</c>.
+    /// Leaves two-digit runways (<c>"28R"</c>) and non-runway digits
+    /// untouched because the regex only fires at word boundaries around a
+    /// lone digit followed by an optional L/R/C.
+    /// </summary>
+    public static string PadSingleDigit(string input) =>
+        SingleDigitRunwayRegex().Replace(input, "0$1");
+
+    /// <summary>
+    /// True when a user-supplied runway filter matches a stored runway
+    /// identifier after stripping leading zeros on both sides. Handles the
+    /// common case where the user types <c>"4"</c> or <c>"4L"</c> and the
+    /// data has <c>"04L"</c>. Matches the CLI's <c>_filter_by_runways</c>
+    /// behavior: prefix match on the normalized form, so <c>"17"</c>
+    /// catches <c>"17"</c>, <c>"17L"</c>, and <c>"17R"</c>.
+    /// </summary>
+    public static bool FilterMatches(string filter, string runway)
+    {
+        var normalizedFilter = filter.TrimStart('0');
+        var normalizedRunway = runway.TrimStart('0');
+        return normalizedRunway.Equals(normalizedFilter, StringComparison.OrdinalIgnoreCase)
+            || normalizedRunway.StartsWith(normalizedFilter, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [GeneratedRegex(@"\b(\d[LRC]?)\b", RegexOptions.IgnoreCase)]
+    private static partial Regex SingleDigitRunwayRegex();
+}


### PR DESCRIPTION
## Summary
Three small fixes to make the `/terminal` commands behave like the standalone zoa-reference-cli tool. Independent of #75 — no file-level conflict expected, though both PRs touch `ChartCommand.cs` in different places.

- **chart** — Add `TAXI` → `AIRPORT DIAGRAM` and `DVA` → `DIVERSE VECTOR AREA` aliases so shorthand queries open the right chart directly. Mirrors `charts.py:_normalize_chart_name` in the CLI.
- **approaches** — Strip leading zeros from both the user runway filter and the stored runway before comparing. `ApproachConnection.Runway` is stored zero-padded (`"04L"` from `"RWY 04L"`), so previously `approaches RNO SCOLA1 4` returned nothing and the user had to type `04`. Mirrors `_filter_by_runways` in the CLI.
- **navaid** — When the user passes multiple positional args (`navaid SFO OAK RNO`), look each up separately instead of joining them into one substring query that never matches anything. A single-token query still works the same; multi-word names still work with quotes.

## Test plan
- [ ] `chart OAK TAXI` opens Oakland's Airport Diagram directly
- [ ] `chart OAK DVA` opens the DVA chart (if one exists for OAK)
- [ ] `approaches RNO SCOLA1 4` returns runway 04 connections (previously empty)
- [ ] `approaches RNO SCOLA1 17L` still filters correctly to runway 17L
- [ ] `navaid SFO OAK RNO` prints three navaid blocks, one per input
- [ ] `navaid SJC` still returns a single result block (unchanged)
- [ ] `navaid "San Francisco"` still works for multi-word names via quotes