### PR TITLE
feat: resolve navaid aliases and digit suffixes in chart queries

### DIFF
--- a/Features/Nasr/Services/NasrDataService.cs
+++ b/Features/Nasr/Services/NasrDataService.cs
@@ -1,10 +1,11 @@
 using System.IO.Compression;
+using System.Text.RegularExpressions;
 using Microsoft.Extensions.Caching.Memory;
 using ZoaReference.Features.Nasr.Models;
 
 namespace ZoaReference.Features.Nasr.Services;
 
-public class NasrDataService(
+public partial class NasrDataService(
     ILogger<NasrDataService> logger,
     IHttpClientFactory httpClientFactory,
     IMemoryCache cache)
@@ -58,6 +59,78 @@ public class NasrDataService(
         var navaids = await GetNavaids(ct);
         return navaids.FirstOrDefault(n => n.Id.Equals(id, StringComparison.OrdinalIgnoreCase));
     }
+
+    /// <summary>
+    /// Rewrites chart-name-style inputs that use a navaid identifier into the navaid's
+    /// station name, so fuzzy/substring matching can find the corresponding chart.
+    /// Mirrors the CLI's <c>nasr.py:resolve_navaid_alias</c>.
+    /// </summary>
+    /// <remarks>
+    /// Two patterns are recognized:
+    /// <list type="bullet">
+    /// <item><c>FMG1</c> → <c>MUSTANG1</c> (identifier + single digit)</item>
+    /// <item><c>FMG FIVE</c> → <c>MUSTANG FIVE</c> (identifier + trailing words)</item>
+    /// </list>
+    /// When the leading token is not a known navaid identifier, the input is returned unchanged.
+    /// Only the first word of the navaid's station name is used (e.g. "MUSTANG" from "MUSTANG VORTAC").
+    /// </remarks>
+    public async Task<string> ResolveNavaidAlias(string input, CancellationToken ct = default)
+    {
+        var trimmed = input.Trim();
+        if (trimmed.Length == 0)
+        {
+            return input;
+        }
+
+        // Pattern 1: single token ending in one digit, e.g. "FMG1"
+        var match1 = IdentWithDigitRegex().Match(trimmed);
+        if (match1.Success)
+        {
+            var ident = match1.Groups[1].Value;
+            var digit = match1.Groups[2].Value;
+            var firstWord = await GetNavaidFirstWord(ident, ct);
+            if (firstWord is not null)
+            {
+                return $"{firstWord}{digit}";
+            }
+            return input;
+        }
+
+        // Pattern 2: first token is a navaid identifier, followed by one or more words
+        var spaceIdx = trimmed.IndexOf(' ');
+        if (spaceIdx > 0)
+        {
+            var ident = trimmed[..spaceIdx];
+            var rest = trimmed[(spaceIdx + 1)..];
+            if (IdentOnlyRegex().IsMatch(ident))
+            {
+                var firstWord = await GetNavaidFirstWord(ident, ct);
+                if (firstWord is not null)
+                {
+                    return $"{firstWord} {rest}";
+                }
+            }
+        }
+
+        return input;
+    }
+
+    private async Task<string?> GetNavaidFirstWord(string ident, CancellationToken ct)
+    {
+        var navaid = await GetNavaidById(ident, ct);
+        if (navaid is null || string.IsNullOrWhiteSpace(navaid.Name))
+        {
+            return null;
+        }
+        var spaceIdx = navaid.Name.IndexOf(' ');
+        return spaceIdx < 0 ? navaid.Name : navaid.Name[..spaceIdx];
+    }
+
+    [GeneratedRegex(@"^([A-Z]+)(\d)$")]
+    private static partial Regex IdentWithDigitRegex();
+
+    [GeneratedRegex(@"^[A-Z]+$")]
+    private static partial Regex IdentOnlyRegex();
 
     /// <summary>
     /// Finds a navaid whose station name starts with the given word (as stored in NASR AWY records).

--- a/Features/Terminal/Commands/ChartCommand.cs
+++ b/Features/Terminal/Commands/ChartCommand.cs
@@ -2,12 +2,16 @@ using System.Text;
 using System.Text.RegularExpressions;
 using ZoaReference.Features.Charts.Services;
 using ZoaReference.Features.IcaoReference.Repositories;
+using ZoaReference.Features.Nasr.Services;
 using ZoaReference.Features.Terminal.Services;
 
 namespace ZoaReference.Features.Terminal.Commands;
 
-public partial class ChartCommand(AviationApiChartService chartService, AirportRepository airportRepository,
-    ChartPdfProcessingService chartPdfProcessingService) : ITerminalCommand
+public partial class ChartCommand(
+    AviationApiChartService chartService,
+    AirportRepository airportRepository,
+    ChartPdfProcessingService chartPdfProcessingService,
+    NasrDataService nasrDataService) : ITerminalCommand
 {
     private static readonly Dictionary<string, string> DigitToWord = new()
     {
@@ -53,14 +57,10 @@ public partial class ChartCommand(AviationApiChartService chartService, AirportR
         if (args.Positional.Length >= 2)
         {
             var rawFilter = string.Join(" ", args.Positional[1..]);
-            // Expand whole-string aliases (TAXI → AIRPORT DIAGRAM, DVA → DIVERSE
-            // VECTOR AREA) before normalizing runways so shorthand queries work.
-            var aliased = ChartNameAliases.TryGetValue(rawFilter.Trim(), out var substitution)
-                ? substitution
-                : rawFilter;
-            // Pad single-digit runway numbers (e.g. "RNAV 4L" → "RNAV 04L")
-            // so users don't need the leading zero for IAPs.
-            var filter = RunwayFormat.PadSingleDigit(aliased);
+            // Normalize the filter so shorthand queries (TAXI, FMG1, DYAMD5, RNAV 4L)
+            // match real chart names like "AIRPORT DIAGRAM", "MUSTANG ONE",
+            // "DYAMD FIVE", "RNAV (GPS) RWY 04L".
+            var filter = await NormalizeChartQuery(rawFilter);
             var codeFilter = args.Positional[1].ToUpperInvariant();
 
             // Try chart code first (DP, STAR, IAP, APD, etc.)
@@ -155,6 +155,49 @@ public partial class ChartCommand(AviationApiChartService chartService, AirportR
         "IAP" => 3,
         _ => 4
     };
+
+    /// <summary>
+    /// Normalizes a chart search query so shorthand forms match real chart names.
+    /// Mirrors <c>charts.py:_normalize_chart_name</c> in the standalone CLI.
+    /// Steps (in order):
+    ///   1. Whole-string aliases (<c>TAXI</c> → <c>AIRPORT DIAGRAM</c>, <c>DVA</c> → <c>DIVERSE VECTOR AREA</c>).
+    ///   2. Navaid alias resolution (<c>FMG1</c> → <c>MUSTANG1</c>, <c>FMG FIVE</c> → <c>MUSTANG FIVE</c>).
+    ///   3. SID/STAR digit suffix expansion (<c>DYAMD5</c> → <c>DYAMD FIVE</c>, <c>MUSTANG1</c> → <c>MUSTANG ONE</c>).
+    ///   4. Runway zero-padding via <see cref="RunwayFormat.PadSingleDigit"/> so
+    ///      <c>"ILS 4L"</c> matches stored chart names like <c>"ILS OR LOC RWY 04L"</c>.
+    /// </summary>
+    private async Task<string> NormalizeChartQuery(string rawFilter)
+    {
+        var trimmed = rawFilter.Trim();
+        if (trimmed.Length == 0)
+        {
+            return rawFilter;
+        }
+
+        // Step 1: whole-string aliases (check before uppercasing so the dict's
+        // OrdinalIgnoreCase comparer handles the user's original casing).
+        if (ChartNameAliases.TryGetValue(trimmed, out var aliased))
+        {
+            return aliased;
+        }
+
+        // Step 2: navaid alias resolution
+        var upper = trimmed.ToUpperInvariant();
+        var resolved = await nasrDataService.ResolveNavaidAlias(upper);
+
+        // Step 3: single-token IDENT+DIGIT → IDENT + DIGIT_WORD
+        var match = SidStarPatternRegex().Match(resolved);
+        if (match.Success && DigitToWord.TryGetValue(match.Groups[2].Value, out var word))
+        {
+            resolved = $"{match.Groups[1].Value} {word}";
+        }
+
+        // Step 4: pad single-digit runway numbers so "4L" hits "04L" in chart names.
+        return RunwayFormat.PadSingleDigit(resolved);
+    }
+
+    [GeneratedRegex(@"^([A-Z]+)(\d)$")]
+    private static partial Regex SidStarPatternRegex();
 
     /// <summary>
     /// Token-based fuzzy match: splits query like "dyamd5" into alpha+digit parts,


### PR DESCRIPTION
## Summary
Second terminal-parity PR (Tier 2a in the parity plan). Extends the `chart` command's query normalization so more shorthand forms match real chart names, mirroring `charts.py:_normalize_chart_name` in the standalone zoa-reference-cli.

- **Navaid alias resolution.** New `NasrDataService.ResolveNavaidAlias(string)` rewrites `FMG1` → `MUSTANG1` and `FMG FIVE` → `MUSTANG FIVE` by looking up the navaid identifier and taking the first word of its station name. Falls through unchanged when the leading token isn't a known navaid. Mirrors `nasr.py:resolve_navaid_alias`.
- **Digit-suffix expansion.** `ChartCommand.NormalizeChartQuery` now also applies a whole-string regex `^([A-Z]+)(\d)$` to turn `DYAMD5` → `DYAMD FIVE` and `MUSTANG1` → `MUSTANG ONE`. The existing token-level digit-word fallback in `FuzzyMatchChart` stays for multi-token queries like `DYAMD 5` or `ILS 5R` that don't match the whole-string regex.
- **Refactor.** The inline `ChartNameAliases.TryGetValue` check added in #76 is folded into the new `NormalizeChartQuery` pipeline so all three transformations (alias dict → navaid alias → digit suffix) live in one place.

**Deliberately NOT included:** airport-code expansion (`RNO1` at RNO → `RENO ONE`). The standalone CLI does this via a hardcoded airport-name map. Rather than port the map, we're deferring to the next PR (Tier 2b, full fuzzy scoring) which will handle `RNO`↔`RENO` via Levenshtein edit distance instead.

## Dependency
Depends on #76 (Tier 1). This branch is stacked on top of `fix/terminal-small-parity-fixes`. If #76 merges first, this PR will retarget against the updated `main` cleanly. If this merges first, #76 will need a trivial rebase.

## Test plan
- [ ] `chart RNO FMG1` opens MUSTANG ONE departure (navaid alias + digit suffix)
- [ ] `chart SFO DYAMD5` opens DYAMD FIVE arrival (digit suffix, no navaid)
- [ ] `chart OAK TAXI` still opens Oakland's Airport Diagram (Tier 1 alias still works)
- [ ] `chart OAK ILS 28R` still works (multi-token query, not affected by normalization)
- [ ] `chart RNO` still lists all RNO charts (no filter, no normalization)
- [ ] `chart BOGUS FMG1` still errors cleanly (airport not found)