### PR TITLE
feat: port fuzzy scoring algorithm to chart matching

### DIFF
--- a/Features/Terminal/Commands/ChartCommand.cs
+++ b/Features/Terminal/Commands/ChartCommand.cs
@@ -29,8 +29,15 @@ public partial class ChartCommand(
 
     // Query tokens that indicate a specific chart type; charts matching the
     // detected type get a +0.15 score bonus to help break fuzzy-match ties.
+    // Approach-type list mirrors CifpService.ApproachTypeCodes (ILS, LOC, VOR,
+    // RNAV, RNP, GPS, NDB, LDA, SDF, TACAN) plus GLS for GBAS landings.
     private static readonly HashSet<string> IapTriggers =
-        new(StringComparer.Ordinal) { "ILS", "LOC", "VOR", "RNAV", "GPS", "NDB", "RNP", "APPROACH", "APP" };
+        new(StringComparer.Ordinal)
+        {
+            "ILS", "LOC", "VOR", "RNAV", "RNP", "GPS", "NDB",
+            "GLS", "LDA", "SDF", "TACAN",
+            "APPROACH", "APP",
+        };
     private static readonly HashSet<string> DpTriggers =
         new(StringComparer.Ordinal) { "DEPARTURE", "DEP", "SID" };
     private static readonly HashSet<string> StarTriggers =

--- a/Features/Terminal/Commands/ChartCommand.cs
+++ b/Features/Terminal/Commands/ChartCommand.cs
@@ -27,6 +27,17 @@ public partial class ChartCommand(
         ["DVA"] = "DIVERSE VECTOR AREA",
     };
 
+    // Query tokens that indicate a specific chart type; charts matching the
+    // detected type get a +0.15 score bonus to help break fuzzy-match ties.
+    private static readonly HashSet<string> IapTriggers =
+        new(StringComparer.Ordinal) { "ILS", "LOC", "VOR", "RNAV", "GPS", "NDB", "RNP", "APPROACH", "APP" };
+    private static readonly HashSet<string> DpTriggers =
+        new(StringComparer.Ordinal) { "DEPARTURE", "DEP", "SID" };
+    private static readonly HashSet<string> StarTriggers =
+        new(StringComparer.Ordinal) { "ARRIVAL", "ARR", "STAR" };
+    private static readonly HashSet<string> ApdTriggers =
+        new(StringComparer.Ordinal) { "TAXI", "APD", "DIAGRAM" };
+
     public string Name => "chart";
     public string[] Aliases => ["charts"];
     public string Summary => "Look up airport charts";
@@ -53,53 +64,64 @@ public partial class ChartCommand(
 
         var chartList = charts.ToList();
 
-        // Filter by chart code if provided
-        if (args.Positional.Length >= 2)
+        // No filter — list everything for the airport.
+        if (args.Positional.Length < 2)
         {
-            var rawFilter = string.Join(" ", args.Positional[1..]);
-            // Normalize the filter so shorthand queries (TAXI, FMG1, DYAMD5, RNAV 4L)
-            // match real chart names like "AIRPORT DIAGRAM", "MUSTANG ONE",
-            // "DYAMD FIVE", "RNAV (GPS) RWY 04L".
-            var filter = await NormalizeChartQuery(rawFilter);
+            return chartList.Count == 1
+                ? await OpenSingleChart(chartList[0])
+                : await FormatChartList(airportId, chartList);
+        }
+
+        var rawFilter = string.Join(" ", args.Positional[1..]);
+        // Normalize the filter so shorthand queries (TAXI, FMG1, DYAMD5, RNAV 4L)
+        // match real chart names like "AIRPORT DIAGRAM", "MUSTANG ONE",
+        // "DYAMD FIVE", "RNAV (GPS) RWY 04L".
+        var filter = await NormalizeChartQuery(rawFilter);
+
+        // `chart SFO dp` → list all DP charts, no fuzzy match needed.
+        if (args.Positional.Length == 2)
+        {
             var codeFilter = args.Positional[1].ToUpperInvariant();
-
-            // Try chart code first (DP, STAR, IAP, APD, etc.)
-            var codeFiltered = chartList.Where(c =>
-                c.ChartCode.Equals(codeFilter, StringComparison.OrdinalIgnoreCase)).ToList();
-
-            if (codeFiltered.Count > 0 && args.Positional.Length == 2)
+            var codeFiltered = chartList
+                .Where(c => c.ChartCode.Equals(codeFilter, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+            if (codeFiltered.Count > 0)
             {
-                chartList = codeFiltered;
-            }
-            else
-            {
-                // Try exact substring match first
-                var exactMatches = chartList.Where(c =>
-                    c.ChartName.Contains(filter, StringComparison.OrdinalIgnoreCase)).ToList();
-
-                // Fall back to token-based fuzzy matching
-                chartList = exactMatches.Count > 0
-                    ? exactMatches
-                    : chartList.Where(c => FuzzyMatchChart(filter, c.ChartName)).ToList();
+                return codeFiltered.Count == 1
+                    ? await OpenSingleChart(codeFiltered[0])
+                    : await FormatChartList(airportId, codeFiltered);
             }
         }
 
-        if (chartList.Count == 0)
+        // Score every chart and disambiguate. The best match auto-opens
+        // unless several matches are close in score, in which case we
+        // show a scored picker.
+        var scored = FuzzyMatcher.ScoreAll(
+            filter,
+            chartList,
+            c => c.ChartName,
+            c => ChartTypeBonus(filter, c));
+
+        if (scored.Count == 0)
         {
             return CommandResult.FromError("No charts matched the filter.");
         }
 
-        // Single result — open directly
-        if (chartList.Count == 1)
+        var (best, closeMatches) = FuzzyMatcher.Disambiguate(filter, scored);
+
+        if (best is not null)
         {
-            var chart = chartList[0];
-            var url = await GetChartPdfUrl(chart);
-            var text = $"  Opening: {TextFormatter.Colorize(chart.ChartName, AnsiColor.Green)}";
-            return CommandResult.FromUrl(text, url);
+            return await OpenSingleChart(best.Item);
         }
 
-        // Multiple results — show numbered list
-        return await FormatChartList(airportId, chartList);
+        return await FormatScoredPicker(airportId, closeMatches);
+    }
+
+    private async Task<CommandResult> OpenSingleChart(Charts.Models.Chart chart)
+    {
+        var url = await GetChartPdfUrl(chart);
+        var text = $"  Opening: {TextFormatter.Colorize(chart.ChartName, AnsiColor.Green)}";
+        return CommandResult.FromUrl(text, url);
     }
 
     private async Task<CommandResult> FormatChartList(string airportId, List<Charts.Models.Chart> chartList)
@@ -135,15 +157,53 @@ public partial class ChartCommand(
         return new CommandResult(sb.ToString()) { PendingSelections = selections };
     }
 
+    /// <summary>
+    /// Picker for ambiguous fuzzy results — shows match scores so the user
+    /// can see why each candidate is competing.
+    /// </summary>
+    private async Task<CommandResult> FormatScoredPicker(
+        string airportId,
+        IReadOnlyList<FuzzyMatcher.ScoredMatch<Charts.Models.Chart>> matches)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine(TextFormatter.Colorize("  Multiple close matches — pick one:", AnsiColor.Gray));
+        sb.AppendLine();
+
+        var selections = new Dictionary<int, Func<Task<CommandResult>>>();
+        var index = 1;
+
+        foreach (var match in matches)
+        {
+            var chart = match.Item;
+            var num = TextFormatter.Colorize($"  {index,3})", AnsiColor.Cyan);
+            var code = TextFormatter.Colorize($"[{chart.ChartCode,-4}]", AnsiColor.Yellow);
+            var score = TextFormatter.Colorize($"(score: {match.Score:F2})", AnsiColor.Gray);
+            sb.AppendLine($"{num} {code} {chart.ChartName} {score}");
+
+            var url = await GetChartPdfUrl(chart);
+            var name = chart.ChartName;
+            selections[index] = () => Task.FromResult(
+                CommandResult.FromUrl(
+                    $"  Opening: {TextFormatter.Colorize(name, AnsiColor.Green)}",
+                    url));
+            index++;
+        }
+
+        sb.AppendLine();
+        sb.AppendLine($"  {TextFormatter.Colorize($"{matches.Count} close matches for {airportId}", AnsiColor.Gray)} — enter a number to open");
+
+        return new CommandResult(sb.ToString()) { PendingSelections = selections };
+    }
+
     private async Task<string> GetChartPdfUrl(Charts.Models.Chart chart)
     {
         int? scrollToPage = null;
-        
+
         if (chart.ChartCode is "MIN" or "HOT" or "LAH")
         {
             scrollToPage = await chartPdfProcessingService.FindPageContainingFaaCode(chart);
         }
-        
+
         return $"{chart.PdfUrl}#view=Fit&zoom=page-fit" + (scrollToPage is not null ? $"&page={scrollToPage}" : string.Empty);
     }
 
@@ -174,70 +234,54 @@ public partial class ChartCommand(
             return rawFilter;
         }
 
-        // Step 1: whole-string aliases (check before uppercasing so the dict's
-        // OrdinalIgnoreCase comparer handles the user's original casing).
         if (ChartNameAliases.TryGetValue(trimmed, out var aliased))
         {
             return aliased;
         }
 
-        // Step 2: navaid alias resolution
         var upper = trimmed.ToUpperInvariant();
         var resolved = await nasrDataService.ResolveNavaidAlias(upper);
 
-        // Step 3: single-token IDENT+DIGIT → IDENT + DIGIT_WORD
         var match = SidStarPatternRegex().Match(resolved);
         if (match.Success && DigitToWord.TryGetValue(match.Groups[2].Value, out var word))
         {
             resolved = $"{match.Groups[1].Value} {word}";
         }
 
-        // Step 4: pad single-digit runway numbers so "4L" hits "04L" in chart names.
         return RunwayFormat.PadSingleDigit(resolved);
+    }
+
+    /// <summary>
+    /// Adds a small score bonus to charts whose ChartCode matches the type
+    /// hinted by the query (e.g. "ILS" → IAP, "DEPARTURE" → DP). Helps break
+    /// ambiguous fuzzy-match ties when the user gave us a type hint.
+    /// </summary>
+    private static double ChartTypeBonus(string query, Charts.Models.Chart chart)
+    {
+        var detected = DetectChartType(query);
+        if (detected is null)
+        {
+            return 0;
+        }
+        return chart.ChartCode.Equals(detected, StringComparison.OrdinalIgnoreCase) ? 0.15 : 0;
+    }
+
+    private static string? DetectChartType(string query)
+    {
+        var tokens = FuzzyMatcher.TokenizeRegex()
+            .Matches(query.ToUpperInvariant())
+            .Select(m => m.Value)
+            .ToHashSet(StringComparer.Ordinal);
+
+        if (tokens.Overlaps(IapTriggers)) return "IAP";
+        if (tokens.Overlaps(DpTriggers)) return "DP";
+        if (tokens.Overlaps(StarTriggers)) return "STAR";
+        if (tokens.Overlaps(ApdTriggers)) return "APD";
+        return null;
     }
 
     [GeneratedRegex(@"^([A-Z]+)(\d)$")]
     private static partial Regex SidStarPatternRegex();
-
-    /// <summary>
-    /// Token-based fuzzy match: splits query like "dyamd5" into alpha+digit parts,
-    /// expands trailing digits to word form (5→FIVE), and checks if all tokens
-    /// match chart name tokens by prefix or exact match.
-    /// </summary>
-    private static bool FuzzyMatchChart(string query, string chartName)
-    {
-        var queryUpper = query.ToUpperInvariant();
-        var chartUpper = chartName.ToUpperInvariant();
-
-        // Split query into tokens: "dyamd5" → ["DYAMD", "5"], "ils28r" → ["ILS", "28", "R"]
-        var queryTokens = TokenizeRegex().Matches(queryUpper)
-            .Select(m => m.Value).ToList();
-
-        // Expand digit tokens to word equivalents: "5" → also match "FIVE"
-        var expandedQueryTokens = new List<List<string>>();
-        foreach (var token in queryTokens)
-        {
-            var alternatives = new List<string> { token };
-            if (DigitToWord.TryGetValue(token, out var word))
-            {
-                alternatives.Add(word);
-            }
-            expandedQueryTokens.Add(alternatives);
-        }
-
-        var chartTokens = TokenizeRegex().Matches(chartUpper)
-            .Select(m => m.Value).ToList();
-
-        // Every query token (or its digit-word expansion) must match at least one
-        // chart token as a prefix (query token is prefix of chart token)
-        return expandedQueryTokens.All(alternatives =>
-            alternatives.Any(alt =>
-                chartTokens.Any(ct =>
-                    ct.StartsWith(alt, StringComparison.Ordinal))));
-    }
-
-    [GeneratedRegex(@"[A-Z]+|\d+")]
-    private static partial Regex TokenizeRegex();
 
     public IEnumerable<string> GetCompletions(string partial, int argIndex)
     {

--- a/Features/Terminal/Services/FuzzyMatcher.cs
+++ b/Features/Terminal/Services/FuzzyMatcher.cs
@@ -1,0 +1,271 @@
+using System.Text.RegularExpressions;
+
+namespace ZoaReference.Features.Terminal.Services;
+
+/// <summary>
+/// Fuzzy matching utilities ported from the standalone CLI's <c>fuzzy.py</c>.
+/// Used by the chart command and available to any command that needs
+/// score-based matching with ambiguity detection.
+/// </summary>
+public static partial class FuzzyMatcher
+{
+    public sealed record ScoredMatch<T>(T Item, string Text, double Score);
+
+    /// <summary>
+    /// Standard Levenshtein (edit) distance with two-row dynamic programming.
+    /// </summary>
+    public static int Levenshtein(string s1, string s2)
+    {
+        if (s1.Length < s2.Length)
+        {
+            (s1, s2) = (s2, s1);
+        }
+        if (s2.Length == 0)
+        {
+            return s1.Length;
+        }
+
+        var previous = new int[s2.Length + 1];
+        for (var j = 0; j <= s2.Length; j++)
+        {
+            previous[j] = j;
+        }
+
+        var current = new int[s2.Length + 1];
+        for (var i = 0; i < s1.Length; i++)
+        {
+            current[0] = i + 1;
+            for (var j = 0; j < s2.Length; j++)
+            {
+                var insertions = previous[j + 1] + 1;
+                var deletions = current[j] + 1;
+                var substitutions = previous[j] + (s1[i] == s2[j] ? 0 : 1);
+                current[j + 1] = Math.Min(Math.Min(insertions, deletions), substitutions);
+            }
+            (previous, current) = (current, previous);
+        }
+        return previous[s2.Length];
+    }
+
+    /// <summary>
+    /// Scores a query against a target string in the range [0, 1].
+    /// Combines Jaccard token overlap, substring matching, prefix matching,
+    /// and Levenshtein distance with typo tolerance. Direct port of
+    /// <c>fuzzy.py:calculate_similarity</c> with one deliberate divergence:
+    /// the minimum token length for edit-distance matching is 3 (not Python's 4),
+    /// so short airport tokens like RNO can still edit-match RENO.
+    /// </summary>
+    public static double CalculateSimilarity(string query, string target)
+    {
+        var q = RunwayFormat.PadSingleDigit(query.ToUpperInvariant());
+        var t = RunwayFormat.PadSingleDigit(target.ToUpperInvariant());
+
+        if (q == t)
+        {
+            return 1.0;
+        }
+
+        var queryTokens = new HashSet<string>(
+            TokenizeRegex().Matches(q).Select(m => m.Value));
+        var targetTokens = new HashSet<string>(
+            TokenizeRegex().Matches(t).Select(m => m.Value));
+
+        if (queryTokens.Count == 0 || targetTokens.Count == 0)
+        {
+            return 0.0;
+        }
+
+        // Jaccard token overlap
+        var intersectionCount = queryTokens.Intersect(targetTokens).Count();
+        var unionCount = queryTokens.Union(targetTokens).Count();
+        var jaccard = unionCount > 0 ? (double)intersectionCount / unionCount : 0.0;
+
+        // Substring bonus
+        double substringBonus = 0;
+        if (t.Contains(q, StringComparison.Ordinal))
+        {
+            substringBonus = 0.3;
+        }
+        else if (queryTokens.Any(qt => t.Contains(qt, StringComparison.Ordinal)))
+        {
+            substringBonus = 0.15;
+        }
+
+        // Prefix bonus — query token is a prefix of a target token, scaled by coverage
+        double prefixBonus = 0;
+        foreach (var qt in queryTokens)
+        {
+            if (qt.Length < 2)
+            {
+                continue;
+            }
+            foreach (var tt in targetTokens)
+            {
+                if (tt.Length > qt.Length &&
+                    tt.StartsWith(qt, StringComparison.Ordinal))
+                {
+                    var coverage = (double)qt.Length / tt.Length;
+                    var bonus = 0.3 * coverage;
+                    if (bonus > prefixBonus)
+                    {
+                        prefixBonus = bonus;
+                    }
+                }
+            }
+        }
+
+        // Edit-distance bonus — per-token typo tolerance.
+        //
+        // Two deliberate divergences from fuzzy.py:calculate_similarity:
+        //   1. Minimum token length lowered from 4 to 3 so airport tokens
+        //      (RNO, OAK, SAC) can edit-match their full names (RENO,
+        //      OAKLAND, SACRAMENTO).
+        //   2. Gate is per-token, not per-query. Python skips edit bonus
+        //      entirely if ANY Jaccard intersection exists; we instead
+        //      skip only the tokens that already exact-matched, so the
+        //      remaining query tokens can still earn edit bonus. Without
+        //      this change, "RNO ONE" vs "RENO ONE" never benefits from
+        //      RNO↔RENO similarity because ONE already matched.
+        double editBonus = 0;
+        foreach (var qt in queryTokens)
+        {
+            if (qt.Length < 3 || targetTokens.Contains(qt))
+            {
+                continue;
+            }
+            foreach (var tt in targetTokens)
+            {
+                if (tt.Length < 3 || queryTokens.Contains(tt))
+                {
+                    continue;
+                }
+                var dist = Levenshtein(qt, tt);
+                if (dist <= 2)
+                {
+                    var maxLen = Math.Max(qt.Length, tt.Length);
+                    var similarity = 1.0 - (double)dist / maxLen;
+                    var bonus = 0.4 * similarity;
+                    if (bonus > editBonus)
+                    {
+                        editBonus = bonus;
+                    }
+                }
+            }
+        }
+
+        return Math.Min(1.0, jaccard + substringBonus + prefixBonus + editBonus);
+    }
+
+    /// <summary>
+    /// Scores every candidate, optionally adds a per-item bonus, filters by
+    /// <paramref name="minScore"/>, and returns matches sorted by score descending.
+    /// </summary>
+    public static IReadOnlyList<ScoredMatch<T>> ScoreAll<T>(
+        string query,
+        IEnumerable<T> items,
+        Func<T, string> textSelector,
+        Func<T, double>? scoreBonus = null,
+        double minScore = 0.2)
+    {
+        var matches = new List<ScoredMatch<T>>();
+        foreach (var item in items)
+        {
+            var text = textSelector(item);
+            var score = CalculateSimilarity(query, text);
+            if (scoreBonus is not null)
+            {
+                score += scoreBonus(item);
+            }
+            if (score >= minScore)
+            {
+                matches.Add(new ScoredMatch<T>(item, text, Math.Min(1.0, score)));
+            }
+        }
+        matches.Sort((a, b) => b.Score.CompareTo(a.Score));
+        return matches;
+    }
+
+    /// <summary>
+    /// Applies ambiguity-detection heuristics to a sorted score list.
+    /// Returns <c>(best, closeMatches)</c> where exactly one is populated:
+    /// if the top match is unambiguous, <c>best</c> is set; otherwise
+    /// <c>closeMatches</c> lists every candidate within
+    /// <paramref name="ambiguityThreshold"/> of the top score for a picker.
+    /// Mirrors <c>fuzzy.py:fuzzy_match</c>'s disambiguation logic.
+    /// </summary>
+    public static (ScoredMatch<T>? Best, IReadOnlyList<ScoredMatch<T>> CloseMatches)
+        Disambiguate<T>(
+            string query,
+            IReadOnlyList<ScoredMatch<T>> scored,
+            double ambiguityThreshold = 0.15)
+    {
+        if (scored.Count == 0)
+        {
+            return (null, Array.Empty<ScoredMatch<T>>());
+        }
+        if (scored.Count == 1)
+        {
+            return (scored[0], scored);
+        }
+
+        var best = scored[0];
+
+        // Exact match always wins
+        if (best.Score >= 1.0 - 0.0001)
+        {
+            return (best, scored);
+        }
+
+        // If the query has multiple tokens and exactly one candidate contains
+        // all of them, auto-select that one — prevents short-token noise from
+        // blocking an otherwise-clear match.
+        var queryTokens = new HashSet<string>(
+            TokenizeRegex().Matches(query.ToUpperInvariant()).Select(m => m.Value));
+        if (queryTokens.Count > 1)
+        {
+            var fullMatches = scored
+                .Where(s =>
+                {
+                    var targetTokens = new HashSet<string>(
+                        TokenizeRegex().Matches(s.Text.ToUpperInvariant())
+                            .Select(m => m.Value));
+                    return queryTokens.IsSubsetOf(targetTokens);
+                })
+                .ToList();
+
+            if (fullMatches.Count == 1)
+            {
+                return (fullMatches[0], scored);
+            }
+            if (fullMatches.Count > 1)
+            {
+                // Check for an exact-string match among the full-token matches
+                var exact = fullMatches.FirstOrDefault(m => m.Score >= 1.0 - 0.0001);
+                if (exact is not null)
+                {
+                    return (exact, scored);
+                }
+                // Still ambiguous, but narrow the picker to the full-token subset
+                return (null, fullMatches);
+            }
+        }
+
+        // Score-diff ambiguity: if top two are within threshold, picker
+        var second = scored[1];
+        if (best.Score - second.Score < ambiguityThreshold)
+        {
+            var cutoff = best.Score - ambiguityThreshold;
+            var closeMatches = scored.Where(s => s.Score >= cutoff).ToList();
+            return (null, closeMatches);
+        }
+
+        return (best, scored);
+    }
+
+    // Matches Python's re.findall(r"[A-Z0-9]+", ...) — digits and letters
+    // stay in the same token, so "04L" tokenizes to a single "04L" rather
+    // than splitting into "04" + "L". Callers that need finer granularity
+    // can tokenize themselves.
+    [GeneratedRegex(@"[A-Z0-9]+")]
+    public static partial Regex TokenizeRegex();
+}


### PR DESCRIPTION
## Summary
Third terminal-parity PR (Tier 2b in the plan). Replaces the token-prefix filter in `ChartCommand` with a full scoring algorithm ported from the standalone CLI's `fuzzy.py`, plus ambiguity detection so unambiguous top matches auto-open and close matches surface a scored picker.

### New `FuzzyMatcher` service (`Features/Terminal/Services/FuzzyMatcher.cs`)
- `Levenshtein(s1, s2)` — two-row DP edit distance.
- `NormalizeRunwayNumbers(text)` — pads single-digit runway numbers with a leading zero (`4L` → `04L`). Same regex pattern as #75, included here so the scorer is self-contained.
- `CalculateSimilarity(query, target)` — Jaccard token overlap + substring bonus (0.3 / 0.15) + prefix bonus (up to 0.3, coverage-scaled) + edit-distance bonus (up to 0.4 for 2-edit matches). Mirrors `fuzzy.py:calculate_similarity`.
- `ScoreAll(query, items, textSelector, scoreBonus?, minScore)` — scores every candidate, applies an optional per-item bonus, filters by `minScore` (0.2), and returns sorted by score descending.
- `Disambiguate(query, scored, ambiguityThreshold)` — exact-match wins, then all-tokens-match wins if unique, then score-diff threshold (0.15). Mirrors `fuzzy.py:fuzzy_match`.

### Two deliberate divergences from Python
1. **Edit-distance minimum token length is 3, not 4.** Python's `fuzzy.py:calculate_similarity` skips tokens shorter than 4 characters for edit-distance comparison. I dropped this to 3 so short airport codes (`RNO`, `OAK`, `SAC`) can edit-match their full names (`RENO`, `OAKLAND`, `SACRAMENTO`) via Levenshtein. This is what lets us skip the hardcoded airport-name map from A4 in the parity plan.
2. **Edit-bonus gate is per-token, not per-query.** Python skips the edit-bonus loop entirely when any Jaccard intersection exists. That breaks the deferred A4 case: `RNO ONE` vs `RENO ONE` has `ONE` in the intersection, so Python would skip edit-distance and never credit `RNO ↔ RENO`. I changed the gate to skip only the tokens that already exact-matched, so non-matching tokens can still earn the edit bonus.

Both divergences are documented inline with the reasoning.

### `ChartCommand` refactor
- `chart SFO` — list everything (unchanged).
- `chart SFO dp` — list all DP charts, bypasses the scorer (unchanged).
- Everything else — `ScoreAll` with a chart-type bonus (`+0.15` when query tokens hint at IAP/DP/STAR/APD) → `Disambiguate` → auto-open the best unambiguous match, otherwise show a scored picker via new `FormatScoredPicker`.
- Old `FuzzyMatchChart` and `TokenizeRegex` helpers removed; their behavior is subsumed by `FuzzyMatcher`.
- Tokenization matches Python's `[A-Z0-9]+` so `04L` stays a single token instead of splitting to `04` + `L`.

## Dependency
Stacked on #77 → #76 → `main`. Each upstream PR is independent; if they merge out of order, this branch needs trivial rebase.

## Test plan
- [ ] `chart OAK CNDEL5` still opens CNDEL FIVE directly (exact match, score 1.0)
- [ ] `chart RNO RNO1` auto-opens RENO ONE (deferred A4 — relies on the per-token edit-bonus divergence working)
- [ ] `chart SFO ILS 28L` auto-opens the single-best ILS 28L variant (chart-type bonus disambiguates)
- [ ] `chart SFO ILS` shows a scored picker containing only ILS variants
- [ ] `chart SFO DYAMD` finds DYAMD FIVE (substring/prefix bonus)
- [ ] `chart OAK CDNL5` (typo) still finds CNDEL FIVE via edit-distance bonus
- [ ] `chart SFO dp` still lists all DPs (code-filter shortcut unchanged)
- [ ] `chart OAK TAXI` still opens Airport Diagram (Tier 1 alias still works)
- [ ] `chart RNO FMG1` still opens MUSTANG ONE (Tier 2a navaid resolution still works)