### PR TITLE
feat: parse multi-airway routes in the mea command

### DIFF
--- a/Features/Terminal/Commands/MeaCommand.cs
+++ b/Features/Terminal/Commands/MeaCommand.cs
@@ -1,27 +1,34 @@
 using System.Text;
+using System.Text.RegularExpressions;
+using ZoaReference.Features.Nasr.Models;
 using ZoaReference.Features.Nasr.Services;
 using ZoaReference.Features.Terminal.Services;
 
 namespace ZoaReference.Features.Terminal.Commands;
 
-public class MeaCommand(NasrDataService nasrDataService) : ITerminalCommand
+public partial class MeaCommand(NasrDataService nasrDataService) : ITerminalCommand
 {
+    private sealed record MeaSegment(string Airway, string FromFix, string ToFix, int MeaFt, int? MocaFt);
+
+    private sealed record RouteLeg(string Airway, string EntryFix, string ExitFix);
+
     public string Name => "mea";
     public string[] Aliases => [];
-    public string Summary => "Show MEA/MOCA between fixes on an airway";
-    public string Usage => "mea <fix1> <fix2> [-a altitude]\n" +
-                           "    mea SJC MOD        — Show MEA/MOCA for SJC to MOD\n" +
-                           "    mea SJC MOD -a 50  — Highlight segments with MEA above 5000ft and show SAFE/WARNING";
+    public string Summary => "Show MEA/MOCA for an airway route or between two fixes";
+    public string Usage => "mea <route...> [-a altitude]\n" +
+                           "    mea SAC V25 SWR               — Show MEA for V25 segment SAC → SWR\n" +
+                           "    mea KSFO V25 SAC J80 KRNO     — Multi-airway route\n" +
+                           "    mea SAC V25 SWR -a 70         — Check if 7,000 ft clears the MEA\n" +
+                           "    mea SJC MOD                   — Fallback: common airways between two fixes";
 
     public async Task<CommandResult> ExecuteAsync(CommandArgs args)
     {
         if (args.Positional.Length < 2)
-            return CommandResult.FromError("Usage: mea <fix1> <fix2> [-a altitude]");
+        {
+            return CommandResult.FromError("Usage: mea <route...> [-a altitude]");
+        }
 
-        var fix1 = args.Positional[0].ToUpperInvariant();
-        var fix2 = args.Positional[1].ToUpperInvariant();
-
-        // Accept both -a and --a (and --altitude for good measure)
+        // Accept -a, --a, or --altitude for the alert altitude in hundreds of feet.
         int? alertAltitude = null;
         foreach (var key in new[] { "a", "altitude" })
         {
@@ -31,14 +38,84 @@ public class MeaCommand(NasrDataService nasrDataService) : ITerminalCommand
                 break;
             }
         }
+        var alertAltFt = alertAltitude.HasValue ? alertAltitude.Value * 100 : (int?)null;
 
+        // Dot-separators are common in filed routes ("SAC.V25.SWR"); normalize
+        // them to spaces so the user can paste a filed route verbatim.
+        var tokens = args.Positional
+            .SelectMany(p => p.Split('.', StringSplitOptions.RemoveEmptyEntries))
+            .Select(t => t.ToUpperInvariant())
+            .ToArray();
+
+        // Route mode vs fix-pair fallback: if the user gave us any airway
+        // tokens, treat the whole thing as a route; otherwise fall back to
+        // "common airways between two fixes" for the existing two-arg shortcut.
+        var hasAirway = tokens.Any(IsAirway);
+
+        if (hasAirway)
+        {
+            return await RunRouteMode(tokens, alertAltFt);
+        }
+
+        if (tokens.Length != 2)
+        {
+            return CommandResult.FromError(
+                "Without an airway in the route, mea expects exactly two fixes.\n" +
+                "Usage: mea <route...> [-a altitude]");
+        }
+
+        return await RunFixPairMode(tokens[0], tokens[1], alertAltFt);
+    }
+
+    private async Task<CommandResult> RunRouteMode(string[] tokens, int? alertAltFt)
+    {
+        var legs = ParseRoute(tokens);
+        if (legs.Count == 0)
+        {
+            return CommandResult.FromError(
+                "Could not parse any airway segments from the route.\n" +
+                "Each airway needs a fix before and after it, e.g. `SAC V25 SWR`.");
+        }
+
+        var allSegments = new List<MeaSegment>();
+        var unresolvedLegs = new List<string>();
+
+        foreach (var leg in legs)
+        {
+            var segs = await CollectSegmentsForLeg(leg);
+            if (segs.Count == 0)
+            {
+                unresolvedLegs.Add($"{leg.EntryFix} {leg.Airway} {leg.ExitFix}");
+                continue;
+            }
+            allSegments.AddRange(segs);
+        }
+
+        if (allSegments.Count == 0)
+        {
+            var detail = unresolvedLegs.Count > 0
+                ? "\nNo MEA/MOCA data for: " + string.Join(", ", unresolvedLegs)
+                : "";
+            return CommandResult.FromError("No MEA/MOCA data found for this route." + detail);
+        }
+
+        var routeLabel = string.Join(" ", tokens);
+        return RenderSegments(routeLabel, allSegments, alertAltFt, unresolvedLegs);
+    }
+
+    private async Task<CommandResult> RunFixPairMode(string fix1, string fix2, int? alertAltFt)
+    {
         var fix1Coords = await nasrDataService.GetWaypointCoordinates(fix1);
         var fix2Coords = await nasrDataService.GetWaypointCoordinates(fix2);
 
         if (fix1Coords is null)
+        {
             return CommandResult.FromError($"Fix '{fix1}' not found in NASR data");
+        }
         if (fix2Coords is null)
+        {
             return CommandResult.FromError($"Fix '{fix2}' not found in NASR data");
+        }
 
         var fix1Airways = await nasrDataService.FindAirwaysContainingFix(fix1);
         var fix2Airways = await nasrDataService.FindAirwaysContainingFix(fix2);
@@ -46,87 +123,239 @@ public class MeaCommand(NasrDataService nasrDataService) : ITerminalCommand
         var commonAirways = fix1Airways.Where(a => fix2Set.Contains(a)).ToList();
 
         if (commonAirways.Count == 0)
+        {
             return CommandResult.FromError($"No common airway found between {fix1} and {fix2}");
+        }
 
-        // Collect all relevant segments across all common airways
-        var allSegments = new List<(string Airway, string From, string To, int Mea, int? Moca)>();
-
+        // For each common airway, run the same segment-range collection used
+        // by route mode so fix-pair mode shares one code path.
+        var allSegments = new List<MeaSegment>();
         foreach (var airwayId in commonAirways)
         {
-            var restrictions = await nasrDataService.GetAirwayRestrictions(airwayId);
-            foreach (var r in restrictions)
-            {
-                if ((r.FromFix.Equals(fix1, StringComparison.OrdinalIgnoreCase) ||
-                     r.FromFix.Equals(fix2, StringComparison.OrdinalIgnoreCase) ||
-                     r.ToFix.Equals(fix1, StringComparison.OrdinalIgnoreCase) ||
-                     r.ToFix.Equals(fix2, StringComparison.OrdinalIgnoreCase)) &&
-                    r.Mea.HasValue)
-                {
-                    allSegments.Add((airwayId, r.FromFix, r.ToFix, r.Mea!.Value * 100,
-                        r.Moca.HasValue ? r.Moca.Value * 100 : null));
-                }
-            }
+            var leg = new RouteLeg(airwayId, fix1, fix2);
+            allSegments.AddRange(await CollectSegmentsForLeg(leg));
         }
 
         if (allSegments.Count == 0)
+        {
             return CommandResult.FromError($"No MEA/MOCA data found between {fix1} and {fix2}");
+        }
 
-        // Sort segments by MEA descending (highest restriction first)
-        allSegments.Sort((a, b) => b.Mea.CompareTo(a.Mea));
+        return RenderSegments($"{fix1} → {fix2}", allSegments, alertAltFt, unresolvedLegs: []);
+    }
 
-        var maxMea = allSegments[0].Mea;
-        var alertAltFt = alertAltitude.HasValue ? alertAltitude.Value * 100 : (int?)null;
+    /// <summary>
+    /// Walks a route token stream and produces one <see cref="RouteLeg"/> per
+    /// airway token, scanning backward/forward for the nearest fix-like token.
+    /// Mirrors the scan logic in <c>mea.py:get_mea_for_route</c>.
+    /// </summary>
+    private static List<RouteLeg> ParseRoute(string[] tokens)
+    {
+        var legs = new List<RouteLeg>();
+        for (var i = 0; i < tokens.Length; i++)
+        {
+            if (!IsAirway(tokens[i]))
+            {
+                continue;
+            }
+
+            var airway = tokens[i];
+
+            string? entryFix = null;
+            for (var j = i - 1; j >= 0; j--)
+            {
+                if (IsFixToken(tokens[j]))
+                {
+                    entryFix = tokens[j];
+                    break;
+                }
+            }
+
+            string? exitFix = null;
+            for (var j = i + 1; j < tokens.Length; j++)
+            {
+                if (IsFixToken(tokens[j]))
+                {
+                    exitFix = tokens[j];
+                    break;
+                }
+            }
+
+            if (entryFix is not null && exitFix is not null)
+            {
+                legs.Add(new RouteLeg(airway, entryFix, exitFix));
+            }
+        }
+        return legs;
+    }
+
+    /// <summary>
+    /// For a single leg (airway + entry/exit fixes), finds all restrictions
+    /// whose endpoints fall within the traversed sequence range on the airway.
+    /// Mirrors <c>mea.py:get_mea_for_route</c>: when one of the entry/exit fixes
+    /// can't be resolved on the airway (e.g. the user gave us an airport ICAO
+    /// at the route boundary), fall back to returning every restriction on the
+    /// airway rather than silently dropping the leg.
+    /// </summary>
+    private async Task<List<MeaSegment>> CollectSegmentsForLeg(RouteLeg leg)
+    {
+        var fixes = await nasrDataService.GetAirwayFixes(leg.Airway);
+        var restrictions = await nasrDataService.GetAirwayRestrictions(leg.Airway);
+        if (fixes.Count == 0 || restrictions.Count == 0)
+        {
+            return [];
+        }
+
+        int? entrySeq = null, exitSeq = null;
+        foreach (var fix in fixes)
+        {
+            if (entrySeq is null && fix.FixId.Equals(leg.EntryFix, StringComparison.OrdinalIgnoreCase))
+            {
+                entrySeq = fix.Sequence;
+            }
+            if (exitSeq is null && fix.FixId.Equals(leg.ExitFix, StringComparison.OrdinalIgnoreCase))
+            {
+                exitSeq = fix.Sequence;
+            }
+        }
+
+        HashSet<string>? traversed = null;
+        if (entrySeq is not null && exitSeq is not null)
+        {
+            var minSeq = Math.Min(entrySeq.Value, exitSeq.Value);
+            var maxSeq = Math.Max(entrySeq.Value, exitSeq.Value);
+            traversed = new HashSet<string>(
+                fixes.Where(f => f.Sequence >= minSeq && f.Sequence <= maxSeq)
+                    .Select(f => f.FixId),
+                StringComparer.OrdinalIgnoreCase);
+        }
+
+        var segments = new List<MeaSegment>();
+        foreach (var r in restrictions)
+        {
+            if (r.Mea is null) continue;
+            if (traversed is not null)
+            {
+                if (!traversed.Contains(r.FromFix)) continue;
+                if (!traversed.Contains(r.ToFix)) continue;
+            }
+
+            segments.Add(new MeaSegment(
+                leg.Airway,
+                r.FromFix,
+                r.ToFix,
+                r.Mea.Value * 100,
+                r.Moca.HasValue ? r.Moca.Value * 100 : null));
+        }
+        return segments;
+    }
+
+    private static CommandResult RenderSegments(
+        string routeLabel,
+        List<MeaSegment> allSegments,
+        int? alertAltFt,
+        List<string> unresolvedLegs)
+    {
+        allSegments.Sort((a, b) => b.MeaFt.CompareTo(a.MeaFt));
+        var maxMea = allSegments[0].MeaFt;
+
         var sb = new StringBuilder();
 
-        // Safety status or max MEA summary
         if (alertAltFt.HasValue)
         {
-            var isSafe = alertAltFt.Value >= maxMea;
-            if (isSafe)
+            if (alertAltFt.Value >= maxMea)
             {
                 sb.AppendLine(TextFormatter.Colorize(
-                    $"SAFE: {alertAltFt.Value:N0} ft meets MEA requirement of {maxMea:N0} ft",
+                    $"SAFE: {alertAltFt.Value:N0} ft meets MEA requirement of {maxMea:N0} ft on {routeLabel}",
                     AnsiColor.Green));
             }
             else
             {
                 sb.AppendLine(TextFormatter.Colorize(
-                    $"WARNING: {alertAltFt.Value:N0} ft is BELOW required MEA of {maxMea:N0} ft",
+                    $"WARNING: {alertAltFt.Value:N0} ft is BELOW required MEA of {maxMea:N0} ft on {routeLabel}",
                     AnsiColor.Yellow));
             }
             sb.AppendLine();
         }
         else
         {
-            sb.AppendLine($"Maximum MEA: {maxMea:N0} ft");
+            sb.AppendLine($"Maximum MEA on {routeLabel}: {maxMea:N0} ft");
             sb.AppendLine();
         }
 
-        // Segment table, grouped by airway
-        foreach (var airwayId in commonAirways)
+        // Group segments by airway, preserving the route order (first
+        // appearance wins). Within each airway group, keep the sequence as
+        // returned by CollectSegmentsForLeg.
+        var airwayOrder = new List<string>();
+        var byAirway = new Dictionary<string, List<MeaSegment>>(StringComparer.OrdinalIgnoreCase);
+        foreach (var seg in allSegments.OrderByDescending(s => s.MeaFt))
         {
-            var airwaySegs = allSegments.Where(s => s.Airway == airwayId).ToList();
-            if (airwaySegs.Count == 0) continue;
+            if (!byAirway.TryGetValue(seg.Airway, out var list))
+            {
+                list = [];
+                byAirway[seg.Airway] = list;
+                airwayOrder.Add(seg.Airway);
+            }
+            list.Add(seg);
+        }
 
+        foreach (var airwayId in airwayOrder)
+        {
+            var airwaySegs = byAirway[airwayId];
             var widths = new[] { 12, 12, 10, 10 };
-            sb.Append(TextFormatter.FormatTableHeader($"MEA/MOCA — {airwayId}: {fix1} → {fix2}",
+            sb.Append(TextFormatter.FormatTableHeader($"MEA/MOCA — {airwayId}",
                 ["From", "To", "MEA", "MOCA"], widths));
 
-            foreach (var (_, from, to, mea, moca) in airwaySegs)
+            foreach (var seg in airwaySegs)
             {
-                var meaStr = $"{mea:N0}";
-                var mocaStr = moca.HasValue ? $"{moca.Value:N0}" : "-";
+                var meaStr = $"{seg.MeaFt:N0}";
+                var mocaStr = seg.MocaFt.HasValue ? $"{seg.MocaFt.Value:N0}" : "-";
 
-                var isAboveAlert = alertAltFt.HasValue && mea > alertAltFt.Value;
-                if (isAboveAlert)
+                if (alertAltFt.HasValue && seg.MeaFt > alertAltFt.Value)
+                {
                     meaStr = TextFormatter.Colorize(meaStr, AnsiColor.Red);
+                }
 
-                sb.AppendLine(TextFormatter.FormatTableRow([from, to, meaStr, mocaStr], widths));
+                sb.AppendLine(TextFormatter.FormatTableRow([seg.FromFix, seg.ToFix, meaStr, mocaStr], widths));
             }
+        }
+
+        if (unresolvedLegs.Count > 0)
+        {
+            sb.AppendLine();
+            sb.AppendLine(TextFormatter.Colorize(
+                "  No MEA/MOCA data for: " + string.Join(", ", unresolvedLegs),
+                AnsiColor.Gray));
         }
 
         return CommandResult.FromText(sb.ToString());
     }
+
+    private static bool IsAirway(string token) => AirwayRegex().IsMatch(token);
+
+    /// <summary>
+    /// SID/STAR identifiers look like <c>CNDEL5</c> or <c>SCOLA1A</c> — alpha
+    /// then digit then optional alpha — and are always longer than 5 chars
+    /// (plain fixes like <c>SAC</c> or <c>MOD</c> don't match). When scanning
+    /// for a fix adjacent to an airway we skip these so the entry/exit come
+    /// from the fix on either side of the procedure, not the procedure itself.
+    /// </summary>
+    private static bool IsSidStarName(string token) =>
+        token.Length > 5 && SidStarRegex().IsMatch(token);
+
+    private static bool IsFixToken(string token)
+    {
+        if (token.Equals("DCT", StringComparison.OrdinalIgnoreCase)) return false;
+        if (IsAirway(token)) return false;
+        if (IsSidStarName(token)) return false;
+        return true;
+    }
+
+    [GeneratedRegex(@"^[VJTQ]\d+$")]
+    private static partial Regex AirwayRegex();
+
+    [GeneratedRegex(@"^[A-Z]+\d+[A-Z]*$")]
+    private static partial Regex SidStarRegex();
 
     public IEnumerable<string> GetCompletions(string partial, int argIndex) => [];
 }


### PR DESCRIPTION
## Summary
Fourth terminal-parity PR (Tier 3a in the plan). Extends the `mea` command to accept filed-route-style input with interleaved airways and fixes, mirroring the standalone CLI's `mea.py:get_mea_for_route`.

### Before
```
mea <fix1> <fix2> [-a altitude]
```
Only two fixes at a time, with the command finding their common airways and listing MEA for the restrictions between them.

### After
```
mea <route...> [-a altitude]
  mea SAC V25 SWR            — Single-airway segment
  mea KSFO V25 SAC J80 KRNO  — Multi-airway route
  mea SAC.V25.SWR            — Dot-separators from filed routes
  mea SJC MOD                — Fallback: two-fix common-airways (unchanged)
```

### Implementation
- `ParseRoute` scans for airway tokens matching `^[VJTQ]\d+$` and, for each, looks backward/forward for the nearest fix-like token. Skips `DCT`, other airways, and SID/STAR identifiers (pattern `^[A-Z]+\d+[A-Z]*$` longer than 5 chars), matching the scan rules in `mea.py`.
- `CollectSegmentsForLeg` looks up the airway's fixes (sorted by sequence), finds the entry/exit sequence numbers, and filters restrictions whose both endpoints fall inside the traversed range. **Fallback:** if either endpoint can't be resolved on the airway (e.g. the user gave `KSFO` as the entry for `V25`), it falls back to returning every restriction on the airway — same behavior as the Python CLI, which leaves `in_range = True` when one sequence is `None`.
- Dot-separators in filed routes are normalized to spaces before parsing, so `SAC.V25.SWR` parses identically to `SAC V25 SWR`.
- The existing two-fix shortcut (`mea SJC MOD`) is preserved as a fallback when the input contains no airway tokens. It now shares the `CollectSegmentsForLeg` code path instead of duplicating the restriction-filter logic from the old implementation.
- Output groups rows by airway (in route order), computes a single SAFE/WARNING verdict across the whole route, and lists any unresolved legs in a gray footer.

This PR is independent of #76, #77, and #78 — it branches directly off `main` and only touches `Features/Terminal/Commands/MeaCommand.cs`. No file-level conflict with the stacked chart PRs.

## Test plan
- [ ] `mea SAC V25 SWR` returns the V25 segment MEA/MOCA table (unchanged from old single-airway behavior)
- [ ] `mea KSFO V25 SAC J80 KRNO -a 180` shows a multi-segment table covering both V25 and J80, with a single SAFE/WARNING verdict based on the highest MEA across the route
- [ ] `mea SAC.V25.SWR` parses the same as `SAC V25 SWR` (dot normalization)
- [ ] `mea SJC MOD` still works via the two-fix fallback
- [ ] `mea SJC MOD -a 50` still flags segments above 5,000 ft
- [ ] `mea KSFO CNDEL5 DYAMD V25 SAC` correctly picks `DYAMD` (not `CNDEL5`) as V25's entry fix, because `CNDEL5` matches the SID/STAR skip pattern