### PR TITLE
feat: add uses terminal command for cross-airport fix search

### DIFF
--- a/Features/Charts/Models/CifpProcedureDetail.cs
+++ b/Features/Charts/Models/CifpProcedureDetail.cs
@@ -21,3 +21,12 @@ public record CifpLeg(
     double? Course,
     double? Distance,
     FixRole Role);
+
+/// <summary>
+/// One (airport, procedure, type) tuple returned by a cross-airport CIFP fix
+/// search — e.g. when answering "which procedures contain MYJAW?".
+/// </summary>
+public record CifpFixUsage(
+    string Airport,
+    string ProcedureId,
+    CifpProcedureType Type);

--- a/Features/Charts/Services/CifpService.cs
+++ b/Features/Charts/Services/CifpService.cs
@@ -255,6 +255,112 @@ public partial class CifpService(
             allLegs.OrderBy(x => x.Sequence).Select(x => x.Leg).ToList());
     }
 
+    /// <summary>
+    /// Scans the full CIFP text for every procedure whose leg list contains the
+    /// given fix identifier, optionally filtered by airport (FAA or 4-letter
+    /// ICAO) and/or procedure type. Deduplicates by
+    /// <c>(airport, base procedure id, type)</c> so a procedure with multiple
+    /// legs on the fix appears once. Mirrors <c>cifp.py:find_fix_uses</c>.
+    /// </summary>
+    public async Task<IReadOnlyList<CifpFixUsage>> FindProceduresUsingFix(
+        string fixId,
+        string? airportFilter = null,
+        CifpProcedureType? typeFilter = null,
+        CancellationToken ct = default)
+    {
+        var cifpText = await GetCifpText(ct);
+        if (cifpText is null)
+        {
+            return [];
+        }
+
+        var fixUpper = fixId.ToUpperInvariant().Trim();
+        if (string.IsNullOrEmpty(fixUpper))
+        {
+            return [];
+        }
+
+        string? airportLinePrefix = null;
+        if (!string.IsNullOrEmpty(airportFilter))
+        {
+            var apt = airportFilter.ToUpperInvariant().TrimStart('K');
+            airportLinePrefix = $"SUSAP K{apt}";
+        }
+
+        char? filterChar = typeFilter switch
+        {
+            CifpProcedureType.SID => 'D',
+            CifpProcedureType.STAR => 'E',
+            CifpProcedureType.Approach => 'F',
+            _ => null
+        };
+
+        var results = new List<CifpFixUsage>();
+        var seen = new HashSet<(string, string, CifpProcedureType)>();
+
+        using var reader = new StringReader(cifpText);
+        while (await reader.ReadLineAsync(ct) is { } line)
+        {
+            if (line.Length < 35) continue;
+            if (!line.StartsWith("SUSAP", StringComparison.Ordinal)) continue;
+            if (airportLinePrefix is not null
+                && !line.StartsWith(airportLinePrefix, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var sub = line[12];
+            CifpProcedureType procType;
+            switch (sub)
+            {
+                case 'D': procType = CifpProcedureType.SID; break;
+                case 'E': procType = CifpProcedureType.STAR; break;
+                case 'F': procType = CifpProcedureType.Approach; break;
+                default: continue;
+            }
+
+            if (filterChar is not null && sub != filterChar.Value) continue;
+
+            // Fix identifier is at line[29..34] (5 chars, may be padded).
+            var lineFix = line[29..34].Trim();
+            if (!lineFix.Equals(fixUpper, StringComparison.Ordinal)) continue;
+
+            // Airport code is at line[6..10] — 4 chars of ICAO, strip the K for
+            // mainland US records so callers see 3-letter FAA codes.
+            var airport = line[6..10].Trim().TrimStart('K');
+            if (string.IsNullOrEmpty(airport)) continue;
+
+            // Procedure ID is at line[13..19] (6 chars).
+            var rawProcId = line[13..19].Trim();
+            if (string.IsNullOrEmpty(rawProcId)) continue;
+
+            // Normalize SID/STAR ids to the base form so e.g. "CNDEL54"
+            // (CNDEL5 with an internal leg index) collapses to "CNDEL5".
+            // Approaches keep their full id so "I28R" and "I28L" stay distinct.
+            string baseId;
+            if (sub == 'D' || sub == 'E')
+            {
+                var match = SidStarBaseIdRegex().Match(rawProcId);
+                baseId = match.Success ? match.Groups[1].Value : rawProcId;
+            }
+            else
+            {
+                baseId = rawProcId;
+            }
+
+            var key = (airport, baseId, procType);
+            if (seen.Add(key))
+            {
+                results.Add(new CifpFixUsage(airport, baseId, procType));
+            }
+        }
+
+        return results;
+    }
+
+    [GeneratedRegex(@"^([A-Z]+\d)")]
+    private static partial Regex SidStarBaseIdRegex();
+
     public async Task<Dictionary<string, CifpApproach>> GetApproachesForAirport(
         string airport, CancellationToken ct = default)
     {

--- a/Features/Terminal/Commands/UsesCommand.cs
+++ b/Features/Terminal/Commands/UsesCommand.cs
@@ -1,0 +1,136 @@
+using System.Text;
+using ZoaReference.Features.Charts.Models;
+using ZoaReference.Features.Charts.Services;
+using ZoaReference.Features.Terminal.Services;
+
+namespace ZoaReference.Features.Terminal.Commands;
+
+public class UsesCommand(CifpService cifpService) : ITerminalCommand
+{
+    public string Name => "uses";
+    public string[] Aliases => [];
+    public string Summary => "Find procedures that contain a fix across all airports";
+    public string Usage => "uses <fix> [airport] [type]\n" +
+                           "    uses MYJAW           — All procedures containing MYJAW\n" +
+                           "    uses COREZ BUR       — Only procedures at BUR\n" +
+                           "    uses COREZ SID       — Only SIDs\n" +
+                           "    uses COREZ BUR SID   — Only SIDs at BUR\n" +
+                           "    uses FIX KAPP        — Airport APP (use ICAO to disambiguate)";
+
+    public async Task<CommandResult> ExecuteAsync(CommandArgs args)
+    {
+        if (args.Positional.Length < 1)
+        {
+            return CommandResult.FromError("Usage: uses <fix> [airport] [type]");
+        }
+
+        var fix = args.Positional[0].ToUpperInvariant().Trim();
+        var (airportFilter, typeFilter) = ParseFilters(args.Positional[1..]);
+
+        var procedures = await cifpService.FindProceduresUsingFix(fix, airportFilter, typeFilter);
+
+        if (procedures.Count == 0)
+        {
+            var filters = new List<string>();
+            if (airportFilter is not null) filters.Add($"airport={airportFilter}");
+            if (typeFilter is not null) filters.Add($"type={typeFilter}");
+            var suffix = filters.Count > 0 ? $" ({string.Join(", ", filters)})" : "";
+            return CommandResult.FromError($"No procedures found containing '{fix}'{suffix}");
+        }
+
+        return Format(fix, procedures);
+    }
+
+    /// <summary>
+    /// Classifies each extra positional argument as either an airport filter
+    /// or a procedure-type filter. Matches the CLI's <c>parse_uses_filters</c>
+    /// heuristic: 4-letter K-prefix codes (e.g. <c>KAPP</c>, <c>KSFO</c>) are
+    /// always airports, even if the 3-letter suffix collides with a type
+    /// keyword. Anything that doesn't look like a type keyword becomes the
+    /// airport filter.
+    /// </summary>
+    private static (string? AirportFilter, CifpProcedureType? TypeFilter) ParseFilters(string[] extras)
+    {
+        string? airportFilter = null;
+        CifpProcedureType? typeFilter = null;
+
+        foreach (var arg in extras)
+        {
+            var upper = arg.ToUpperInvariant();
+            var isIcao = upper.Length == 4 && upper.StartsWith('K');
+
+            if (!isIcao)
+            {
+                CifpProcedureType? type = upper switch
+                {
+                    "SID" => CifpProcedureType.SID,
+                    "STAR" => CifpProcedureType.STAR,
+                    "APP" or "IAP" or "APPROACH" => CifpProcedureType.Approach,
+                    _ => null
+                };
+                if (type is not null)
+                {
+                    typeFilter = type;
+                    continue;
+                }
+            }
+
+            // Airport filter: strip K prefix so the filter matches the 3-letter
+            // form that CifpService uses internally.
+            airportFilter = isIcao ? upper[1..] : upper;
+        }
+
+        return (airportFilter, typeFilter);
+    }
+
+    private static CommandResult Format(string fix, IReadOnlyList<CifpFixUsage> procedures)
+    {
+        var byAirport = procedures
+            .GroupBy(p => p.Airport, StringComparer.OrdinalIgnoreCase)
+            .OrderBy(g => g.Key, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        var sb = new StringBuilder();
+        sb.AppendLine($"  {TextFormatter.Colorize(fix, AnsiColor.Yellow)} is used in:");
+        sb.AppendLine();
+
+        foreach (var airportGroup in byAirport)
+        {
+            sb.AppendLine($"  {TextFormatter.Colorize(airportGroup.Key, AnsiColor.Cyan)}:");
+
+            var byType = airportGroup
+                .GroupBy(p => p.Type)
+                .OrderBy(g => TypeOrder(g.Key));
+
+            foreach (var typeGroup in byType)
+            {
+                var label = typeGroup.Key switch
+                {
+                    CifpProcedureType.STAR => "STARs",
+                    CifpProcedureType.SID => "SIDs",
+                    CifpProcedureType.Approach => "Approaches",
+                    _ => "?"
+                };
+                var ids = string.Join(", ", typeGroup
+                    .Select(p => p.ProcedureId)
+                    .OrderBy(i => i, StringComparer.OrdinalIgnoreCase));
+                sb.AppendLine($"    {TextFormatter.Colorize(label + ":", AnsiColor.Gray)} {ids}");
+            }
+            sb.AppendLine();
+        }
+
+        sb.AppendLine($"  {TextFormatter.Colorize($"{procedures.Count} procedures across {byAirport.Count} airport{(byAirport.Count == 1 ? "" : "s")}", AnsiColor.Gray)}");
+
+        return CommandResult.FromText(sb.ToString());
+    }
+
+    private static int TypeOrder(CifpProcedureType type) => type switch
+    {
+        CifpProcedureType.STAR => 0,
+        CifpProcedureType.SID => 1,
+        CifpProcedureType.Approach => 2,
+        _ => 9
+    };
+
+    public IEnumerable<string> GetCompletions(string partial, int argIndex) => [];
+}

--- a/Features/Terminal/TerminalModule.cs
+++ b/Features/Terminal/TerminalModule.cs
@@ -31,6 +31,7 @@ public class TerminalModule : IServiceConfigurator
         services.AddSingleton<ITerminalCommand, ClearCommand>();
         services.AddSingleton<ITerminalCommand, CloseCommand>();
         services.AddSingleton<ITerminalCommand, MetarCommand>();
+        services.AddSingleton<ITerminalCommand, UsesCommand>();
 
         // CommandDispatcher is scoped (one per circuit)
         services.AddScoped<CommandDispatcher>();


### PR DESCRIPTION
## Summary
Fifth and final terminal-parity PR (Tier 3b, trimmed to just the `uses` command per scope decision — `vr` was cut). Adds a new `uses` command that finds every SID / STAR / approach containing a given fix across all airports in the CIFP, mirroring the standalone CLI's `cifp.py:find_fix_uses`.

```
uses <fix> [airport] [type]
  uses MYJAW           — All procedures containing MYJAW
  uses COREZ BUR       — Only procedures at BUR
  uses COREZ SID       — Only SIDs
  uses COREZ BUR SID   — Only SIDs at BUR
  uses FIX KAPP        — Airport APP (use 4-letter ICAO to disambiguate)
```

### Implementation
- **`CifpService.FindProceduresUsingFix`** scans the cached nationwide CIFP text in a single pass, reusing the same record format the rest of `CifpService` already knows about: `SUSAP K{airport}` prefix at positions 0-9, subsection at position 12 (`D`=SID, `E`=STAR, `F`=Approach), procedure ID at 13-19, fix ID at 29-34. Deduplicates by `(airport, base procedure id, type)` so a procedure with multiple legs on the same fix appears once. Normalizes SID/STAR IDs to the base form (`CNDEL54` → `CNDEL5`) via a new `SidStarBaseIdRegex`; approaches keep their full ID so `I28R` and `I28L` stay distinct. Supports optional airport and type filters, both pre-filtered in the scan loop for speed.
- **`CifpFixUsage`** record added to `CifpProcedureDetail.cs` alongside the existing CIFP models.
- **`UsesCommand`** parses `<fix> [airport] [type]`. Extra positional args are classified with the same heuristic as `parse_uses_filters` in the CLI: 4-letter K-prefix codes (`KAPP`, `KSFO`) are always airports, `SID`/`STAR`/`APP`/`IAP` keywords are types, anything else becomes the airport filter. Output is grouped by airport, sub-grouped by type in the order STAR → SID → Approach, matching the CLI's rendering.
- **Registered** in `TerminalModule.cs`.

This PR is independent of the four preceding terminal PRs (#76, #77, #78, #79) — it branches directly off `main` and only touches `Features/Charts/{Models,Services}` and `Features/Terminal/{Commands,TerminalModule}`. No overlap with any other pending branch.

## Test plan
- [ ] `uses MYJAW` prints procedures containing MYJAW across all ZOA airports (grouped by airport and type)
- [ ] `uses COREZ BUR` shows only Burbank's procedures containing COREZ
- [ ] `uses COREZ SID` shows only SIDs (across all airports)
- [ ] `uses COREZ BUR SID` combines both filters
- [ ] `uses FIX KAPP` treats KAPP as an airport ICAO (not as APP type)
- [ ] `uses BOGUS` returns a clean "no procedures found" error
- [ ] Procedures with multiple legs on the same fix appear once (dedup)