### PR TITLE
feat: add PIREP encoder/decoder page at /pirep

### DIFF
--- a/Components/App.razor
+++ b/Components/App.razor
@@ -33,6 +33,7 @@
                 element.focus();
             }
         };
+        window.CopyToClipboard = (text) => navigator.clipboard.writeText(text);
     </script>
     <HeadOutlet/>
     <title>@Settings.Value.ARTCC Reference</title>

--- a/Components/Layout/NavItems.cs
+++ b/Components/Layout/NavItems.cs
@@ -14,6 +14,7 @@ public static class NavItems
         ["videomaps"] = new("/videomaps", "Video Maps"),
         ["procedures"] = new("/procedures", "Procedures"),
         ["scratchpads"] = new("/scratchpads", "Scratchpads"),
+        ["pirep"] = new("/pirep", "PIREP"),
         ["airspaceviz"] = new("/airspaceviz", "Airspace"),
         ["terminal"] = new("/terminal", "Terminal"),
     };
@@ -28,6 +29,7 @@ public static class NavItems
         "videomaps",
         "procedures",
         "scratchpads",
+        "pirep",
         "airspaceviz",
         "terminal"
     ];

--- a/Features/PirepEncoder/Models/CloudLayer.cs
+++ b/Features/PirepEncoder/Models/CloudLayer.cs
@@ -1,0 +1,10 @@
+namespace ZoaReference.Features.PirepEncoder.Models;
+
+public sealed record CloudLayer
+{
+    public string Base { get; init; } = "UNKN";
+
+    public SkyCover Cover { get; init; } = SkyCover.SKC;
+
+    public string? Tops { get; init; }
+}

--- a/Features/PirepEncoder/Models/DraftEntry.cs
+++ b/Features/PirepEncoder/Models/DraftEntry.cs
@@ -1,0 +1,12 @@
+namespace ZoaReference.Features.PirepEncoder.Models;
+
+public sealed record DraftEntry
+{
+    public string Id { get; init; } = Guid.NewGuid().ToString("N");
+
+    public DateTimeOffset SavedAt { get; init; } = DateTimeOffset.UtcNow;
+
+    public string Label { get; init; } = "";
+
+    public Pirep Pirep { get; init; } = new();
+}

--- a/Features/PirepEncoder/Models/Icing.cs
+++ b/Features/PirepEncoder/Models/Icing.cs
@@ -1,0 +1,28 @@
+namespace ZoaReference.Features.PirepEncoder.Models;
+
+public enum IcingIntensity
+{
+    TRACE,
+    LGT,
+    LGT_MDT,
+    MDT,
+    MDT_SVR,
+    SVR,
+}
+
+public enum IcingType
+{
+    None,
+    RIME,
+    CLR,
+    MX,
+}
+
+public sealed record Icing
+{
+    public IcingIntensity Intensity { get; init; } = IcingIntensity.LGT;
+
+    public IcingType Type { get; init; } = IcingType.None;
+
+    public string? AltitudeBand { get; init; }
+}

--- a/Features/PirepEncoder/Models/Location.cs
+++ b/Features/PirepEncoder/Models/Location.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+
+namespace ZoaReference.Features.PirepEncoder.Models;
+
+public sealed record LocationSegment
+{
+    public string Fix { get; init; } = "";
+
+    public string? RadialDistance { get; init; }
+}
+
+public sealed record Location
+{
+    public IReadOnlyList<LocationSegment> Segments { get; init; } = new List<LocationSegment>();
+}

--- a/Features/PirepEncoder/Models/Pirep.cs
+++ b/Features/PirepEncoder/Models/Pirep.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+
+namespace ZoaReference.Features.PirepEncoder.Models;
+
+public sealed record Pirep
+{
+    public string? SaIdentifier { get; init; }
+
+    public ReportType ReportType { get; init; } = ReportType.Routine;
+
+    public Location Location { get; init; } = new();
+
+    public string Time { get; init; } = "";
+
+    public string FlightLevel { get; init; } = "UNKN";
+
+    public string AircraftType { get; init; } = "UNKN";
+
+    public IReadOnlyList<CloudLayer>? SkyCover { get; init; }
+
+    public string? SkyCoverRaw { get; init; }
+
+    public Weather? Weather { get; init; }
+
+    public string? WeatherRaw { get; init; }
+
+    public int? TemperatureC { get; init; }
+
+    public int? WindDirection { get; init; }
+
+    public int? WindSpeedKt { get; init; }
+
+    public Turbulence? Turbulence { get; init; }
+
+    public string? TurbulenceRaw { get; init; }
+
+    public Icing? Icing { get; init; }
+
+    public string? IcingRaw { get; init; }
+
+    public string? Remarks { get; init; }
+}

--- a/Features/PirepEncoder/Models/PirepSettings.cs
+++ b/Features/PirepEncoder/Models/PirepSettings.cs
@@ -1,0 +1,10 @@
+namespace ZoaReference.Features.PirepEncoder.Models;
+
+public sealed record PirepSettings
+{
+    public string? DefaultSaIdentifier { get; init; }
+
+    public bool PrefixWithSaIdentifier { get; init; } = true;
+
+    public string? DefaultAircraftType { get; init; }
+}

--- a/Features/PirepEncoder/Models/ReportType.cs
+++ b/Features/PirepEncoder/Models/ReportType.cs
@@ -1,0 +1,23 @@
+namespace ZoaReference.Features.PirepEncoder.Models;
+
+public enum ReportType
+{
+    Routine,
+    Urgent,
+}
+
+public static class ReportTypeExtensions
+{
+    public static string ToCode(this ReportType type) => type switch
+    {
+        ReportType.Routine => "UA",
+        ReportType.Urgent => "UUA",
+        _ => "UA",
+    };
+
+    public static ReportType FromCode(string code) => code switch
+    {
+        "UUA" => ReportType.Urgent,
+        _ => ReportType.Routine,
+    };
+}

--- a/Features/PirepEncoder/Models/SkyCover.cs
+++ b/Features/PirepEncoder/Models/SkyCover.cs
@@ -1,0 +1,11 @@
+namespace ZoaReference.Features.PirepEncoder.Models;
+
+public enum SkyCover
+{
+    SKC,
+    FEW,
+    SCT,
+    BKN,
+    OVC,
+    OVX,
+}

--- a/Features/PirepEncoder/Models/Turbulence.cs
+++ b/Features/PirepEncoder/Models/Turbulence.cs
@@ -1,0 +1,28 @@
+namespace ZoaReference.Features.PirepEncoder.Models;
+
+public enum TurbulenceIntensity
+{
+    Negative,
+    LGT,
+    LGT_MOD,
+    MOD,
+    MOD_SVR,
+    SVR,
+    EXTRM,
+}
+
+public enum TurbulenceType
+{
+    None,
+    CAT,
+    CHOP,
+}
+
+public sealed record Turbulence
+{
+    public TurbulenceIntensity Intensity { get; init; } = TurbulenceIntensity.LGT;
+
+    public TurbulenceType Type { get; init; } = TurbulenceType.None;
+
+    public string? AltitudeBand { get; init; }
+}

--- a/Features/PirepEncoder/Models/Weather.cs
+++ b/Features/PirepEncoder/Models/Weather.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace ZoaReference.Features.PirepEncoder.Models;
+
+public sealed record Weather
+{
+    public int? FlightVisibilitySm { get; init; }
+
+    public IReadOnlyList<string> Contractions { get; init; } = new List<string>();
+}

--- a/Features/PirepEncoder/PirepModule.cs
+++ b/Features/PirepEncoder/PirepModule.cs
@@ -1,0 +1,8 @@
+using ZoaReference.FeatureUtilities.Interfaces;
+
+namespace ZoaReference.Features.PirepEncoder;
+
+public class PirepModule : IServiceConfigurator
+{
+    public IServiceCollection AddServices(IServiceCollection services) => services;
+}

--- a/Features/PirepEncoder/Services/IcingFormatter.cs
+++ b/Features/PirepEncoder/Services/IcingFormatter.cs
@@ -1,0 +1,33 @@
+using System.Text;
+using ZoaReference.Features.PirepEncoder.Models;
+
+namespace ZoaReference.Features.PirepEncoder.Services;
+
+public static class IcingFormatter
+{
+    public static string Format(Icing ic)
+    {
+        var sb = new StringBuilder();
+        sb.Append(IntensityCode(ic.Intensity));
+        if (ic.Type != IcingType.None)
+        {
+            sb.Append(' ').Append(ic.Type);
+        }
+        if (!string.IsNullOrWhiteSpace(ic.AltitudeBand))
+        {
+            sb.Append(' ').Append(ic.AltitudeBand);
+        }
+        return sb.ToString();
+    }
+
+    public static string IntensityCode(IcingIntensity i) => i switch
+    {
+        IcingIntensity.TRACE => "TRACE",
+        IcingIntensity.LGT => "LGT",
+        IcingIntensity.LGT_MDT => "LGT-MDT",
+        IcingIntensity.MDT => "MDT",
+        IcingIntensity.MDT_SVR => "MDT-SVR",
+        IcingIntensity.SVR => "SVR",
+        _ => "LGT",
+    };
+}

--- a/Features/PirepEncoder/Services/LocationFormatter.cs
+++ b/Features/PirepEncoder/Services/LocationFormatter.cs
@@ -1,0 +1,26 @@
+using System.Text;
+using ZoaReference.Features.PirepEncoder.Models;
+
+namespace ZoaReference.Features.PirepEncoder.Services;
+
+public static class LocationFormatter
+{
+    public static string Format(Location location)
+    {
+        var sb = new StringBuilder();
+        for (var i = 0; i < location.Segments.Count; i++)
+        {
+            if (i > 0)
+            {
+                sb.Append('-');
+            }
+            var segment = location.Segments[i];
+            sb.Append(segment.Fix);
+            if (!string.IsNullOrWhiteSpace(segment.RadialDistance))
+            {
+                sb.Append(' ').Append(segment.RadialDistance);
+            }
+        }
+        return sb.ToString();
+    }
+}

--- a/Features/PirepEncoder/Services/PirepFormatter.cs
+++ b/Features/PirepEncoder/Services/PirepFormatter.cs
@@ -1,0 +1,149 @@
+using System.Globalization;
+using System.Text;
+using ZoaReference.Features.PirepEncoder.Models;
+
+namespace ZoaReference.Features.PirepEncoder.Services;
+
+/// <summary>
+/// Produces a canonical encoded PIREP string from a <see cref="Pirep"/>.
+/// Per FAA Form 7110-2. Pure function: no side effects, no UI refs.
+/// </summary>
+public static class PirepFormatter
+{
+    public static string Format(Pirep pirep, PirepSettings? settings = null)
+    {
+        settings ??= new PirepSettings();
+        var sb = new StringBuilder();
+
+        var said = !string.IsNullOrWhiteSpace(pirep.SaIdentifier) ? pirep.SaIdentifier : settings.DefaultSaIdentifier;
+        if (settings.PrefixWithSaIdentifier && !string.IsNullOrWhiteSpace(said))
+        {
+            sb.Append(said).Append(' ');
+        }
+
+        sb.Append(pirep.ReportType.ToCode());
+
+        sb.Append(" /OV ").Append(LocationFormatter.Format(pirep.Location));
+        sb.Append("/TM ").Append(pirep.Time);
+        sb.Append("/FL").Append(pirep.FlightLevel);
+        sb.Append("/TP ").Append(pirep.AircraftType);
+
+        var firstOptional = true;
+        void AppendOptional(string code, string value)
+        {
+            if (firstOptional)
+            {
+                sb.Append(' ');
+                firstOptional = false;
+            }
+            sb.Append(code).Append(' ').Append(value);
+        }
+
+        var sk = ResolveSky(pirep);
+        if (sk is not null)
+        {
+            AppendOptional("/SK", sk);
+        }
+
+        var wx = ResolveWeather(pirep);
+        if (wx is not null)
+        {
+            AppendOptional("/WX", wx);
+        }
+
+        if (pirep.TemperatureC is int t)
+        {
+            AppendOptional("/TA", FormatTemperature(t));
+        }
+
+        if (pirep.WindDirection is int dir && pirep.WindSpeedKt is int spd)
+        {
+            AppendOptional("/WV", FormatWind(dir, spd));
+        }
+
+        var tb = ResolveTurbulence(pirep);
+        if (tb is not null)
+        {
+            AppendOptional("/TB", tb);
+        }
+
+        var ic = ResolveIcing(pirep);
+        if (ic is not null)
+        {
+            AppendOptional("/IC", ic);
+        }
+
+        if (!string.IsNullOrWhiteSpace(pirep.Remarks))
+        {
+            AppendOptional("/RM", pirep.Remarks.Trim());
+        }
+
+        return sb.ToString();
+    }
+
+    private static string? ResolveSky(Pirep p)
+    {
+        if (!string.IsNullOrWhiteSpace(p.SkyCoverRaw))
+        {
+            return p.SkyCoverRaw.Trim();
+        }
+        if (p.SkyCover is { Count: > 0 } layers)
+        {
+            return SkyFormatter.Format(layers);
+        }
+        return null;
+    }
+
+    private static string? ResolveWeather(Pirep p)
+    {
+        if (!string.IsNullOrWhiteSpace(p.WeatherRaw))
+        {
+            return p.WeatherRaw.Trim();
+        }
+        if (p.Weather is { } wx)
+        {
+            var s = WeatherFormatter.Format(wx);
+            return string.IsNullOrWhiteSpace(s) ? null : s;
+        }
+        return null;
+    }
+
+    private static string? ResolveTurbulence(Pirep p)
+    {
+        if (!string.IsNullOrWhiteSpace(p.TurbulenceRaw))
+        {
+            return p.TurbulenceRaw.Trim();
+        }
+        if (p.Turbulence is { } tb)
+        {
+            return TurbulenceFormatter.Format(tb);
+        }
+        return null;
+    }
+
+    private static string? ResolveIcing(Pirep p)
+    {
+        if (!string.IsNullOrWhiteSpace(p.IcingRaw))
+        {
+            return p.IcingRaw.Trim();
+        }
+        if (p.Icing is { } ic)
+        {
+            return IcingFormatter.Format(ic);
+        }
+        return null;
+    }
+
+    public static string FormatTemperature(int celsius)
+    {
+        var magnitude = System.Math.Abs(celsius).ToString("D2", CultureInfo.InvariantCulture);
+        return celsius < 0 ? "-" + magnitude : magnitude;
+    }
+
+    public static string FormatWind(int direction, int speedKt)
+    {
+        var dir = direction.ToString("D3", CultureInfo.InvariantCulture);
+        var spd = speedKt.ToString("D3", CultureInfo.InvariantCulture);
+        return dir + spd;
+    }
+}

--- a/Features/PirepEncoder/Services/PirepParser.cs
+++ b/Features/PirepEncoder/Services/PirepParser.cs
@@ -1,0 +1,309 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text.RegularExpressions;
+using ZoaReference.Features.PirepEncoder.Models;
+
+namespace ZoaReference.Features.PirepEncoder.Services;
+
+public enum ParseWarningLevel
+{
+    Info,
+    Warning,
+}
+
+public sealed record ParseWarning(ParseWarningLevel Level, string Message, string? Field = null);
+
+public sealed record ParseResult(Pirep Pirep, IReadOnlyList<ParseWarning> Warnings);
+
+/// <summary>
+/// Tolerant parser for PIREP strings per FAA Form 7110-2.
+/// Unknown tokens surface as <see cref="ParseWarning"/>s rather than failing.
+/// </summary>
+public static partial class PirepParser
+{
+    private static readonly string[] KnownCodes =
+        ["OV", "TM", "FL", "TP", "SK", "WX", "TA", "WV", "TB", "IC", "RM"];
+
+    [GeneratedRegex(@"/(OV|TM|FL|TP|SK|WX|TA|WV|TB|IC|RM)", RegexOptions.CultureInvariant)]
+    private static partial Regex FieldCodeRegex();
+
+    public static ParseResult Parse(string input)
+    {
+        var warnings = new List<ParseWarning>();
+        var text = (input ?? "").Trim();
+
+        string? said = null;
+        var reportType = ReportType.Routine;
+
+        var headerMatch = Regex.Match(text, @"^(?:([A-Z0-9]{3,4})\s+)?(UA|UUA)\b", RegexOptions.CultureInvariant);
+        if (!headerMatch.Success)
+        {
+            warnings.Add(new ParseWarning(ParseWarningLevel.Warning, "Could not find UA/UUA report type; assuming UA."));
+        }
+        else
+        {
+            if (headerMatch.Groups[1].Success)
+            {
+                said = headerMatch.Groups[1].Value;
+            }
+            reportType = ReportTypeExtensions.FromCode(headerMatch.Groups[2].Value);
+            text = text[headerMatch.Length..];
+        }
+
+        var fields = SplitFields(text);
+
+        var pirep = new Pirep
+        {
+            SaIdentifier = said,
+            ReportType = reportType,
+        };
+
+        foreach (var (code, raw) in fields)
+        {
+            var value = raw.Trim();
+            switch (code)
+            {
+                case "OV":
+                    pirep = pirep with { Location = ParseLocation(value, warnings) };
+                    break;
+                case "TM":
+                    pirep = pirep with { Time = value };
+                    break;
+                case "FL":
+                    pirep = pirep with { FlightLevel = string.IsNullOrWhiteSpace(value) ? "UNKN" : value };
+                    break;
+                case "TP":
+                    pirep = pirep with { AircraftType = string.IsNullOrWhiteSpace(value) ? "UNKN" : value };
+                    break;
+                case "SK":
+                    pirep = pirep with
+                    {
+                        SkyCoverRaw = value,
+                        SkyCover = TryParseSkyLayers(value, warnings),
+                    };
+                    break;
+                case "WX":
+                    pirep = pirep with
+                    {
+                        WeatherRaw = value,
+                        Weather = TryParseWeather(value),
+                    };
+                    break;
+                case "TA":
+                    if (int.TryParse(value.Replace("M", "-", System.StringComparison.OrdinalIgnoreCase),
+                                      NumberStyles.Integer, CultureInfo.InvariantCulture, out var t))
+                    {
+                        pirep = pirep with { TemperatureC = t };
+                    }
+                    else
+                    {
+                        warnings.Add(new ParseWarning(ParseWarningLevel.Warning, $"Could not parse temperature: '{value}'.", "TA"));
+                    }
+                    break;
+                case "WV":
+                    var wind = value.Replace(" ", "", System.StringComparison.Ordinal);
+                    if (wind.Length == 6 &&
+                        int.TryParse(wind[..3], NumberStyles.Integer, CultureInfo.InvariantCulture, out var dir) &&
+                        int.TryParse(wind[3..], NumberStyles.Integer, CultureInfo.InvariantCulture, out var spd))
+                    {
+                        pirep = pirep with { WindDirection = dir, WindSpeedKt = spd };
+                    }
+                    else
+                    {
+                        warnings.Add(new ParseWarning(ParseWarningLevel.Warning, $"Wind must be 6 digits (direction+speed): '{value}'.", "WV"));
+                    }
+                    break;
+                case "TB":
+                    pirep = pirep with
+                    {
+                        TurbulenceRaw = value,
+                        Turbulence = TryParseTurbulence(value),
+                    };
+                    break;
+                case "IC":
+                    pirep = pirep with
+                    {
+                        IcingRaw = value,
+                        Icing = TryParseIcing(value),
+                    };
+                    break;
+                case "RM":
+                    pirep = pirep with { Remarks = value };
+                    break;
+                default:
+                    warnings.Add(new ParseWarning(ParseWarningLevel.Warning, $"Unrecognized field /{code}.", code));
+                    break;
+            }
+        }
+
+        return new ParseResult(pirep, warnings);
+    }
+
+    private static IReadOnlyList<(string Code, string Value)> SplitFields(string text)
+    {
+        var result = new List<(string, string)>();
+        var matches = FieldCodeRegex().Matches(text);
+        for (var i = 0; i < matches.Count; i++)
+        {
+            var m = matches[i];
+            var code = m.Groups[1].Value;
+            var start = m.Index + m.Length;
+            var end = (i + 1 < matches.Count) ? matches[i + 1].Index : text.Length;
+            var raw = text[start..end];
+            result.Add((code, raw));
+        }
+        return result;
+    }
+
+    private static Location ParseLocation(string value, List<ParseWarning> warnings)
+    {
+        var segments = new List<LocationSegment>();
+        foreach (var part in value.Split('-', System.StringSplitOptions.RemoveEmptyEntries))
+        {
+            var trimmed = part.Trim();
+            if (trimmed.Length == 0)
+            {
+                continue;
+            }
+            var tokens = trimmed.Split(' ', System.StringSplitOptions.RemoveEmptyEntries);
+            if (tokens.Length == 0)
+            {
+                continue;
+            }
+            var fix = tokens[0];
+            string? rd = null;
+            if (tokens.Length >= 2)
+            {
+                rd = tokens[1];
+            }
+            if (tokens.Length > 2)
+            {
+                warnings.Add(new ParseWarning(ParseWarningLevel.Info, $"Extra tokens in location segment '{trimmed}' preserved as remarks-style text.", "OV"));
+            }
+            segments.Add(new LocationSegment { Fix = fix, RadialDistance = rd });
+        }
+        return new Location { Segments = segments };
+    }
+
+    private static IReadOnlyList<CloudLayer>? TryParseSkyLayers(string value, List<ParseWarning> warnings)
+    {
+        var layers = new List<CloudLayer>();
+        foreach (var layer in value.Split('/', System.StringSplitOptions.RemoveEmptyEntries))
+        {
+            var tokens = layer.Trim().Split(' ', System.StringSplitOptions.RemoveEmptyEntries);
+            if (tokens.Length < 2)
+            {
+                warnings.Add(new ParseWarning(ParseWarningLevel.Warning, $"Could not parse sky layer '{layer}'.", "SK"));
+                return null;
+            }
+            if (!System.Enum.TryParse<SkyCover>(tokens[1], out var cover))
+            {
+                warnings.Add(new ParseWarning(ParseWarningLevel.Warning, $"Unknown cloud cover symbol '{tokens[1]}'.", "SK"));
+                return null;
+            }
+            layers.Add(new CloudLayer
+            {
+                Base = tokens[0],
+                Cover = cover,
+                Tops = tokens.Length >= 3 ? tokens[2] : null,
+            });
+        }
+        return layers.Count > 0 ? layers : null;
+    }
+
+    private static Weather? TryParseWeather(string value)
+    {
+        var tokens = value.Split(' ', System.StringSplitOptions.RemoveEmptyEntries);
+        if (tokens.Length == 0)
+        {
+            return null;
+        }
+        int? fv = null;
+        var startIdx = 0;
+        if (tokens[0].StartsWith("FV", System.StringComparison.OrdinalIgnoreCase) &&
+            int.TryParse(tokens[0].AsSpan(2), NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedFv))
+        {
+            fv = parsedFv;
+            startIdx = 1;
+        }
+        var contractions = tokens.Skip(startIdx).ToList();
+        return new Weather { FlightVisibilitySm = fv, Contractions = contractions };
+    }
+
+    private static Turbulence? TryParseTurbulence(string value)
+    {
+        var tokens = value.Split(' ', System.StringSplitOptions.RemoveEmptyEntries);
+        if (tokens.Length == 0)
+        {
+            return null;
+        }
+        var intensity = tokens[0] switch
+        {
+            "NEG" => TurbulenceIntensity.Negative,
+            "LGT" => TurbulenceIntensity.LGT,
+            "LGT-MOD" => TurbulenceIntensity.LGT_MOD,
+            "MOD" => TurbulenceIntensity.MOD,
+            "MOD-SVR" => TurbulenceIntensity.MOD_SVR,
+            "SVR" => TurbulenceIntensity.SVR,
+            "EXTRM" => TurbulenceIntensity.EXTRM,
+            _ => (TurbulenceIntensity?)null,
+        };
+        if (intensity is null)
+        {
+            return null;
+        }
+        var type = TurbulenceType.None;
+        string? band = null;
+        for (var i = 1; i < tokens.Length; i++)
+        {
+            if (tokens[i] is "CAT" or "CHOP")
+            {
+                type = System.Enum.Parse<TurbulenceType>(tokens[i]);
+            }
+            else
+            {
+                band = tokens[i];
+            }
+        }
+        return new Turbulence { Intensity = intensity.Value, Type = type, AltitudeBand = band };
+    }
+
+    private static Icing? TryParseIcing(string value)
+    {
+        var tokens = value.Split(' ', System.StringSplitOptions.RemoveEmptyEntries);
+        if (tokens.Length == 0)
+        {
+            return null;
+        }
+        var intensity = tokens[0] switch
+        {
+            "TRACE" => IcingIntensity.TRACE,
+            "LGT" => IcingIntensity.LGT,
+            "LGT-MDT" => IcingIntensity.LGT_MDT,
+            "MDT" => IcingIntensity.MDT,
+            "MDT-SVR" => IcingIntensity.MDT_SVR,
+            "SVR" => IcingIntensity.SVR,
+            _ => (IcingIntensity?)null,
+        };
+        if (intensity is null)
+        {
+            return null;
+        }
+        var type = IcingType.None;
+        string? band = null;
+        for (var i = 1; i < tokens.Length; i++)
+        {
+            if (tokens[i] is "RIME" or "CLR" or "MX")
+            {
+                type = System.Enum.Parse<IcingType>(tokens[i]);
+            }
+            else
+            {
+                band = tokens[i];
+            }
+        }
+        return new Icing { Intensity = intensity.Value, Type = type, AltitudeBand = band };
+    }
+}

--- a/Features/PirepEncoder/Services/PirepValidator.cs
+++ b/Features/PirepEncoder/Services/PirepValidator.cs
@@ -1,0 +1,109 @@
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using ZoaReference.Features.PirepEncoder.Models;
+
+namespace ZoaReference.Features.PirepEncoder.Services;
+
+public sealed record ValidationError(string Field, string Message);
+
+public static partial class PirepValidator
+{
+    [GeneratedRegex(@"^[A-Z]{3}$", RegexOptions.CultureInvariant)]
+    private static partial Regex ThreeLetterFix();
+
+    [GeneratedRegex(@"^\d{6}$", RegexOptions.CultureInvariant)]
+    private static partial Regex SixDigits();
+
+    [GeneratedRegex(@"^\d{4}$", RegexOptions.CultureInvariant)]
+    private static partial Regex FourDigits();
+
+    [GeneratedRegex(@"^(\d{3}|UNKN)$", RegexOptions.CultureInvariant)]
+    private static partial Regex ThreeDigitsOrUnkn();
+
+    public static IReadOnlyList<ValidationError> Validate(Pirep pirep)
+    {
+        var errors = new List<ValidationError>();
+
+        if (pirep.Location.Segments.Count == 0)
+        {
+            errors.Add(new ValidationError("OV", "Location is required."));
+        }
+        else
+        {
+            foreach (var seg in pirep.Location.Segments)
+            {
+                if (!ThreeLetterFix().IsMatch(seg.Fix))
+                {
+                    errors.Add(new ValidationError("OV", $"Fix '{seg.Fix}' must be a 3-letter NAVAID identifier."));
+                }
+                if (!string.IsNullOrWhiteSpace(seg.RadialDistance) && !SixDigits().IsMatch(seg.RadialDistance))
+                {
+                    errors.Add(new ValidationError("OV", $"Radial/distance '{seg.RadialDistance}' must be exactly 6 digits (rrrddd)."));
+                }
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(pirep.Time))
+        {
+            errors.Add(new ValidationError("TM", "Time is required."));
+        }
+        else if (!FourDigits().IsMatch(pirep.Time))
+        {
+            errors.Add(new ValidationError("TM", "Time must be 4 digits UTC (hhmm)."));
+        }
+        else
+        {
+            var hh = int.Parse(pirep.Time[..2], System.Globalization.CultureInfo.InvariantCulture);
+            var mm = int.Parse(pirep.Time[2..], System.Globalization.CultureInfo.InvariantCulture);
+            if (hh > 23 || mm > 59)
+            {
+                errors.Add(new ValidationError("TM", "Time must be a valid UTC clock value (00:00 - 23:59)."));
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(pirep.FlightLevel) || !ThreeDigitsOrUnkn().IsMatch(pirep.FlightLevel))
+        {
+            errors.Add(new ValidationError("FL", "Altitude must be 3 digits in hundreds of feet, or UNKN."));
+        }
+
+        if (string.IsNullOrWhiteSpace(pirep.AircraftType))
+        {
+            errors.Add(new ValidationError("TP", "Aircraft type is required (up to 4 chars, or UNKN)."));
+        }
+        else if (pirep.AircraftType.Length > 4 && pirep.AircraftType != "UNKN")
+        {
+            errors.Add(new ValidationError("TP", "Aircraft type must be 4 characters or fewer (or UNKN)."));
+        }
+
+        if (pirep.WindDirection is int dir && (dir < 0 || dir > 360))
+        {
+            errors.Add(new ValidationError("WV", "Wind direction must be 0-360 degrees."));
+        }
+        if (pirep.WindSpeedKt is int spd && (spd < 0 || spd > 999))
+        {
+            errors.Add(new ValidationError("WV", "Wind speed must be 0-999 knots."));
+        }
+        if (pirep.WindDirection is not null ^ pirep.WindSpeedKt is not null)
+        {
+            errors.Add(new ValidationError("WV", "Wind requires both direction and speed."));
+        }
+
+        if (pirep.SkyCover is { Count: > 0 } layers)
+        {
+            for (var i = 0; i < layers.Count; i++)
+            {
+                var layer = layers[i];
+                if (!ThreeDigitsOrUnkn().IsMatch(layer.Base))
+                {
+                    errors.Add(new ValidationError("SK", $"Layer {i + 1} base must be 3 digits or UNKN."));
+                }
+                if (!string.IsNullOrWhiteSpace(layer.Tops) && !ThreeDigitsOrUnkn().IsMatch(layer.Tops))
+                {
+                    errors.Add(new ValidationError("SK", $"Layer {i + 1} tops must be 3 digits or UNKN."));
+                }
+            }
+        }
+
+        return errors;
+    }
+}

--- a/Features/PirepEncoder/Services/SkyFormatter.cs
+++ b/Features/PirepEncoder/Services/SkyFormatter.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using System.Text;
+using ZoaReference.Features.PirepEncoder.Models;
+
+namespace ZoaReference.Features.PirepEncoder.Services;
+
+public static class SkyFormatter
+{
+    public static string Format(IReadOnlyList<CloudLayer> layers)
+    {
+        var sb = new StringBuilder();
+        for (var i = 0; i < layers.Count; i++)
+        {
+            if (i > 0)
+            {
+                sb.Append('/');
+            }
+            var layer = layers[i];
+            sb.Append(layer.Base).Append(' ').Append(layer.Cover);
+            if (!string.IsNullOrWhiteSpace(layer.Tops))
+            {
+                sb.Append(' ').Append(layer.Tops);
+            }
+        }
+        return sb.ToString();
+    }
+}

--- a/Features/PirepEncoder/Services/TurbulenceFormatter.cs
+++ b/Features/PirepEncoder/Services/TurbulenceFormatter.cs
@@ -1,0 +1,34 @@
+using System.Text;
+using ZoaReference.Features.PirepEncoder.Models;
+
+namespace ZoaReference.Features.PirepEncoder.Services;
+
+public static class TurbulenceFormatter
+{
+    public static string Format(Turbulence tb)
+    {
+        var sb = new StringBuilder();
+        sb.Append(IntensityCode(tb.Intensity));
+        if (tb.Type != TurbulenceType.None)
+        {
+            sb.Append(' ').Append(tb.Type);
+        }
+        if (!string.IsNullOrWhiteSpace(tb.AltitudeBand))
+        {
+            sb.Append(' ').Append(tb.AltitudeBand);
+        }
+        return sb.ToString();
+    }
+
+    public static string IntensityCode(TurbulenceIntensity i) => i switch
+    {
+        TurbulenceIntensity.Negative => "NEG",
+        TurbulenceIntensity.LGT => "LGT",
+        TurbulenceIntensity.LGT_MOD => "LGT-MOD",
+        TurbulenceIntensity.MOD => "MOD",
+        TurbulenceIntensity.MOD_SVR => "MOD-SVR",
+        TurbulenceIntensity.SVR => "SVR",
+        TurbulenceIntensity.EXTRM => "EXTRM",
+        _ => "LGT",
+    };
+}

--- a/Features/PirepEncoder/Services/WeatherFormatter.cs
+++ b/Features/PirepEncoder/Services/WeatherFormatter.cs
@@ -1,0 +1,29 @@
+using System.Text;
+using ZoaReference.Features.PirepEncoder.Models;
+
+namespace ZoaReference.Features.PirepEncoder.Services;
+
+public static class WeatherFormatter
+{
+    public static string Format(Weather weather)
+    {
+        var sb = new StringBuilder();
+        if (weather.FlightVisibilitySm is int fv)
+        {
+            sb.Append("FV").Append(fv.ToString("D2", System.Globalization.CultureInfo.InvariantCulture));
+        }
+        foreach (var c in weather.Contractions)
+        {
+            if (string.IsNullOrWhiteSpace(c))
+            {
+                continue;
+            }
+            if (sb.Length > 0)
+            {
+                sb.Append(' ');
+            }
+            sb.Append(c);
+        }
+        return sb.ToString();
+    }
+}

--- a/Features/PirepEncoder/UI/Pages/Pirep.razor
+++ b/Features/PirepEncoder/UI/Pages/Pirep.razor
@@ -1,0 +1,988 @@
+@page "/pirep"
+@rendermode InteractiveServer
+@using System.Globalization
+@using ZoaReference.Features.PirepEncoder.Models
+@using ZoaReference.Features.PirepEncoder.Services
+@using Microsoft.Extensions.Options
+@using PirepRecord = ZoaReference.Features.PirepEncoder.Models.Pirep
+
+@inject IJSRuntime Js
+@inject IOptions<AppSettings> AppSettings
+
+<PageTitle>PIREP - @AppSettings.Value.ARTCC Reference</PageTitle>
+
+<div class="flex flex-col text-s gap-4 max-w-4xl">
+
+    @* Header row *@
+    <div class="flex flex-wrap items-center gap-4 border border-slate-600 p-3 rounded">
+        <div class="flex items-center gap-3">
+            <span class="font-bold">Report</span>
+            <label class="flex items-center gap-1">
+                <input type="radio" name="reportType" class="accent-orange-800"
+                       checked="@(_reportType == ReportType.Routine)"
+                       @onchange="@(() => SetReportType(ReportType.Routine))"/>
+                <span>UA (Routine)</span>
+            </label>
+            <label class="flex items-center gap-1">
+                <input type="radio" name="reportType" class="accent-orange-800"
+                       checked="@(_reportType == ReportType.Urgent)"
+                       @onchange="@(() => SetReportType(ReportType.Urgent))"/>
+                <span>UUA (Urgent)</span>
+            </label>
+        </div>
+        <div class="flex items-center gap-2">
+            <label>SA id</label>
+            <input type="text" maxlength="4"
+                   @bind="_saIdentifier" @bind:event="oninput"
+                   class="uppercase bg-transparent border border-gray-500 focus:outline-none focus:bg-gray-700 p-0.5 w-20"
+                   placeholder="(none)"/>
+        </div>
+        <div class="ml-auto">
+            <button type="button" @onclick="@(() => _showSettings = !_showSettings)"
+                    class="rounded bg-slate-700 transition-colors hover:bg-slate-600 p-1 px-2">
+                @(_showSettings ? "Hide settings" : "Settings")
+            </button>
+        </div>
+    </div>
+
+    @* Settings panel (inline disclosure) *@
+    @if (_showSettings)
+    {
+        <div class="border border-slate-600 p-3 rounded flex flex-col gap-2">
+            <div class="font-bold">Defaults (saved in your browser)</div>
+            <div class="flex items-center gap-2">
+                <label class="w-48">Default SA identifier</label>
+                <input type="text" maxlength="4"
+                       @bind="_settingsSaId" @bind:event="oninput" @bind:after="PersistSettings"
+                       class="uppercase bg-transparent border border-gray-500 focus:outline-none focus:bg-gray-700 p-0.5 w-20"/>
+            </div>
+            <div class="flex items-center gap-2">
+                <label class="w-48">Prefix output with SA id</label>
+                <input type="checkbox" class="accent-orange-800"
+                       @bind="_settingsPrefix" @bind:after="PersistSettings"/>
+            </div>
+            <div class="flex items-center gap-2">
+                <label class="w-48">Default aircraft type</label>
+                <input type="text" maxlength="4"
+                       @bind="_settingsDefaultAircraft" @bind:event="oninput" @bind:after="PersistSettings"
+                       class="uppercase bg-transparent border border-gray-500 focus:outline-none focus:bg-gray-700 p-0.5 w-24"/>
+            </div>
+        </div>
+    }
+
+    @* Required fields card *@
+    <div class="border border-slate-600 p-3 rounded flex flex-col gap-3">
+        <div class="font-bold">Required</div>
+
+        @* /OV — Location segments *@
+        <div>
+            <div class="flex items-center gap-2 mb-1">
+                <label class="font-mono w-12">/OV</label>
+                <span class="text-gray-400">Location</span>
+                <button type="button" @onclick="AddLocationSegment"
+                        class="ml-auto rounded bg-orange-900 transition-colors hover:bg-orange-800 p-0.5 px-2">
+                    + Segment
+                </button>
+            </div>
+            @for (var i = 0; i < _locationSegments.Count; i++)
+            {
+                var idx = i;
+                var seg = _locationSegments[idx];
+                <div class="flex items-center gap-2 mb-1 ml-14">
+                    <input type="text" maxlength="3" placeholder="FIX"
+                           value="@seg.Fix"
+                           @oninput="e => UpdateSegmentFix(idx, (string?)e.Value ?? string.Empty)"
+                           class="uppercase bg-transparent border border-gray-500 focus:outline-none focus:bg-gray-700 p-0.5 w-20"/>
+                    <input type="text" maxlength="6" placeholder="rrrddd"
+                           value="@seg.RadialDistance"
+                           @oninput="e => UpdateSegmentRadial(idx, (string?)e.Value ?? string.Empty)"
+                           class="bg-transparent border border-gray-500 focus:outline-none focus:bg-gray-700 p-0.5 w-24"/>
+                    @if (_locationSegments.Count > 1)
+                    {
+                        <button type="button" @onclick="@(() => RemoveLocationSegment(idx))"
+                                class="rounded bg-slate-700 transition-colors hover:bg-slate-600 p-0.5 px-2">
+                            Remove
+                        </button>
+                    }
+                </div>
+            }
+        </div>
+
+        @* /TM — Time *@
+        <div class="flex items-center gap-2">
+            <label class="font-mono w-12">/TM</label>
+            <input type="text" maxlength="4" placeholder="hhmm UTC"
+                   @bind="_time" @bind:event="oninput"
+                   class="bg-transparent border border-gray-500 focus:outline-none focus:bg-gray-700 p-0.5 w-24"/>
+            <button type="button" @onclick="FillTimeNow"
+                    class="rounded bg-orange-900 transition-colors hover:bg-orange-800 p-0.5 px-2">
+                Now
+            </button>
+        </div>
+
+        @* /FL — Flight Level *@
+        <div class="flex items-center gap-2">
+            <label class="font-mono w-12">/FL</label>
+            <input type="text" maxlength="3" placeholder="hundreds ft"
+                   disabled="@_flightLevelUnknown"
+                   @bind="_flightLevelInput" @bind:event="oninput"
+                   class="uppercase bg-transparent border border-gray-500 focus:outline-none focus:bg-gray-700 p-0.5 w-24 disabled:opacity-50"/>
+            <label class="flex items-center gap-1 ml-2">
+                <input type="checkbox" class="accent-orange-800" @bind="_flightLevelUnknown"/>
+                <span>Unknown</span>
+            </label>
+        </div>
+
+        @* /TP — Aircraft Type *@
+        <div class="flex items-center gap-2">
+            <label class="font-mono w-12">/TP</label>
+            <input type="text" maxlength="4" placeholder="B738"
+                   disabled="@_aircraftTypeUnknown"
+                   @bind="_aircraftTypeInput" @bind:event="oninput"
+                   class="uppercase bg-transparent border border-gray-500 focus:outline-none focus:bg-gray-700 p-0.5 w-24 disabled:opacity-50"/>
+            <label class="flex items-center gap-1 ml-2">
+                <input type="checkbox" class="accent-orange-800" @bind="_aircraftTypeUnknown"/>
+                <span>Unknown</span>
+            </label>
+        </div>
+    </div>
+
+    @* Optional sections *@
+    <div class="border border-slate-600 p-3 rounded flex flex-col gap-4">
+        <div class="font-bold">Optional</div>
+
+        @* Sky *@
+        <div class="flex flex-col gap-2">
+            <div class="flex items-center gap-3">
+                <label class="flex items-center gap-1">
+                    <input type="checkbox" class="accent-orange-800" @bind="_includeSky"/>
+                    <span class="font-mono">/SK Sky cover</span>
+                </label>
+                @if (_includeSky)
+                {
+                    <div class="ml-4">
+                        @RenderModeToggle(_skyMode, m => _skyMode = m)
+                    </div>
+                }
+            </div>
+            @if (_includeSky)
+            {
+                if (_skyMode == SectionMode.Raw)
+                {
+                    <input type="text" placeholder="e.g. 025 OVC 095/180 OVC"
+                           @bind="_skyRaw" @bind:event="oninput"
+                           class="bg-transparent border border-gray-500 focus:outline-none focus:bg-gray-700 p-0.5 w-full ml-6"/>
+                }
+                else
+                {
+                    <div class="ml-6 flex flex-col gap-1">
+                        @for (var i = 0; i < _skyLayers.Count; i++)
+                        {
+                            var idx = i;
+                            var layer = _skyLayers[idx];
+                            <div class="flex items-center gap-2">
+                                <input type="text" maxlength="3" placeholder="base"
+                                       value="@layer.Base"
+                                       @oninput="e => _skyLayers[idx].Base = ((string?)e.Value ?? string.Empty).ToUpperInvariant()"
+                                       class="uppercase bg-transparent border border-gray-500 focus:outline-none focus:bg-gray-700 p-0.5 w-20"/>
+                                <select @bind="layer.Cover"
+                                        class="bg-slate-700 border border-gray-500 p-0.5">
+                                    @foreach (var c in Enum.GetValues<SkyCover>())
+                                    {
+                                        <option value="@c">@c</option>
+                                    }
+                                </select>
+                                <input type="text" maxlength="3" placeholder="tops (opt)"
+                                       value="@layer.Tops"
+                                       @oninput="e => _skyLayers[idx].Tops = (string?)e.Value ?? string.Empty"
+                                       class="uppercase bg-transparent border border-gray-500 focus:outline-none focus:bg-gray-700 p-0.5 w-24"/>
+                                @if (_skyLayers.Count > 1)
+                                {
+                                    <button type="button" @onclick="@(() => _skyLayers.RemoveAt(idx))"
+                                            class="rounded bg-slate-700 transition-colors hover:bg-slate-600 p-0.5 px-2">
+                                        Remove
+                                    </button>
+                                }
+                            </div>
+                        }
+                        <div>
+                            <button type="button" @onclick="@(() => _skyLayers.Add(new SkyLayerEditor()))"
+                                    class="rounded bg-orange-900 transition-colors hover:bg-orange-800 p-0.5 px-2">
+                                + Layer
+                            </button>
+                        </div>
+                    </div>
+                }
+            }
+        </div>
+
+        @* Weather *@
+        <div class="flex flex-col gap-2">
+            <div class="flex items-center gap-3">
+                <label class="flex items-center gap-1">
+                    <input type="checkbox" class="accent-orange-800" @bind="_includeWeather"/>
+                    <span class="font-mono">/WX Weather</span>
+                </label>
+                @if (_includeWeather)
+                {
+                    <div class="ml-4">
+                        @RenderModeToggle(_weatherMode, m => _weatherMode = m)
+                    </div>
+                }
+            </div>
+            @if (_includeWeather)
+            {
+                if (_weatherMode == SectionMode.Raw)
+                {
+                    <input type="text" placeholder="e.g. FV03 R or RA OVC"
+                           @bind="_weatherRaw" @bind:event="oninput"
+                           class="bg-transparent border border-gray-500 focus:outline-none focus:bg-gray-700 p-0.5 w-full ml-6"/>
+                }
+                else
+                {
+                    <div class="ml-6 flex flex-wrap items-center gap-3">
+                        <label class="flex items-center gap-1">
+                            Flight vis (SM):
+                            <input type="number" min="0" max="99"
+                                   @bind="_weatherVisibility" @bind:event="oninput"
+                                   class="bg-transparent border border-gray-500 focus:outline-none focus:bg-gray-700 p-0.5 w-16"/>
+                        </label>
+                        <label class="flex items-center gap-1 flex-1">
+                            Contractions:
+                            <input type="text" placeholder="e.g. RA OVC"
+                                   @bind="_weatherContractions" @bind:event="oninput"
+                                   class="uppercase bg-transparent border border-gray-500 focus:outline-none focus:bg-gray-700 p-0.5 flex-1"/>
+                        </label>
+                    </div>
+                }
+            }
+        </div>
+
+        @* Temperature *@
+        <div class="flex items-center gap-3">
+            <label class="flex items-center gap-1">
+                <input type="checkbox" class="accent-orange-800" @bind="_includeTemp"/>
+                <span class="font-mono">/TA Temperature (°C)</span>
+            </label>
+            @if (_includeTemp)
+            {
+                <input type="number" min="-99" max="99"
+                       @bind="_tempC" @bind:event="oninput"
+                       class="bg-transparent border border-gray-500 focus:outline-none focus:bg-gray-700 p-0.5 w-20 ml-2"/>
+            }
+        </div>
+
+        @* Wind *@
+        <div class="flex items-center gap-3 flex-wrap">
+            <label class="flex items-center gap-1">
+                <input type="checkbox" class="accent-orange-800" @bind="_includeWind"/>
+                <span class="font-mono">/WV Wind</span>
+            </label>
+            @if (_includeWind)
+            {
+                <label class="flex items-center gap-1 ml-2">
+                    Dir:
+                    <input type="number" min="0" max="360"
+                           @bind="_windDir" @bind:event="oninput"
+                           class="bg-transparent border border-gray-500 focus:outline-none focus:bg-gray-700 p-0.5 w-20"/>
+                </label>
+                <label class="flex items-center gap-1">
+                    Speed (kt):
+                    <input type="number" min="0" max="999"
+                           @bind="_windSpd" @bind:event="oninput"
+                           class="bg-transparent border border-gray-500 focus:outline-none focus:bg-gray-700 p-0.5 w-20"/>
+                </label>
+            }
+        </div>
+
+        @* Turbulence *@
+        <div class="flex flex-col gap-2">
+            <div class="flex items-center gap-3">
+                <label class="flex items-center gap-1">
+                    <input type="checkbox" class="accent-orange-800" @bind="_includeTurbulence"/>
+                    <span class="font-mono">/TB Turbulence</span>
+                </label>
+                @if (_includeTurbulence)
+                {
+                    <div class="ml-4">
+                        @RenderModeToggle(_turbulenceMode, m => _turbulenceMode = m)
+                    </div>
+                }
+            </div>
+            @if (_includeTurbulence)
+            {
+                if (_turbulenceMode == SectionMode.Raw)
+                {
+                    <input type="text" placeholder="e.g. MOD CAT BLO-090"
+                           @bind="_turbulenceRaw" @bind:event="oninput"
+                           class="bg-transparent border border-gray-500 focus:outline-none focus:bg-gray-700 p-0.5 w-full ml-6"/>
+                }
+                else
+                {
+                    <div class="ml-6 flex flex-wrap items-center gap-3">
+                        <select @bind="_turbIntensity" class="bg-slate-700 border border-gray-500 p-0.5">
+                            @foreach (var v in Enum.GetValues<TurbulenceIntensity>())
+                            {
+                                <option value="@v">@TurbulenceFormatter.IntensityCode(v)</option>
+                            }
+                        </select>
+                        <select @bind="_turbType" class="bg-slate-700 border border-gray-500 p-0.5">
+                            @foreach (var v in Enum.GetValues<TurbulenceType>())
+                            {
+                                <option value="@v">@(v == TurbulenceType.None ? "(none)" : v.ToString())</option>
+                            }
+                        </select>
+                        <input type="text" placeholder="altitude band (opt)"
+                               @bind="_turbBand" @bind:event="oninput"
+                               class="bg-transparent border border-gray-500 focus:outline-none focus:bg-gray-700 p-0.5 w-48"/>
+                    </div>
+                }
+            }
+        </div>
+
+        @* Icing *@
+        <div class="flex flex-col gap-2">
+            <div class="flex items-center gap-3">
+                <label class="flex items-center gap-1">
+                    <input type="checkbox" class="accent-orange-800" @bind="_includeIcing"/>
+                    <span class="font-mono">/IC Icing</span>
+                </label>
+                @if (_includeIcing)
+                {
+                    <div class="ml-4">
+                        @RenderModeToggle(_icingMode, m => _icingMode = m)
+                    </div>
+                }
+            </div>
+            @if (_includeIcing)
+            {
+                if (_icingMode == SectionMode.Raw)
+                {
+                    <input type="text" placeholder="e.g. SVR CLR 028-045"
+                           @bind="_icingRaw" @bind:event="oninput"
+                           class="bg-transparent border border-gray-500 focus:outline-none focus:bg-gray-700 p-0.5 w-full ml-6"/>
+                }
+                else
+                {
+                    <div class="ml-6 flex flex-wrap items-center gap-3">
+                        <select @bind="_icingIntensity" class="bg-slate-700 border border-gray-500 p-0.5">
+                            @foreach (var v in Enum.GetValues<IcingIntensity>())
+                            {
+                                <option value="@v">@IcingFormatter.IntensityCode(v)</option>
+                            }
+                        </select>
+                        <select @bind="_icingType" class="bg-slate-700 border border-gray-500 p-0.5">
+                            @foreach (var v in Enum.GetValues<IcingType>())
+                            {
+                                <option value="@v">@(v == IcingType.None ? "(none)" : v.ToString())</option>
+                            }
+                        </select>
+                        <input type="text" placeholder="altitude band (opt)"
+                               @bind="_icingBand" @bind:event="oninput"
+                               class="bg-transparent border border-gray-500 focus:outline-none focus:bg-gray-700 p-0.5 w-48"/>
+                    </div>
+                }
+            }
+        </div>
+
+        @* Remarks *@
+        <div class="flex items-center gap-3">
+            <label class="flex items-center gap-1">
+                <input type="checkbox" class="accent-orange-800" @bind="_includeRemarks"/>
+                <span class="font-mono">/RM Remarks</span>
+            </label>
+            @if (_includeRemarks)
+            {
+                <input type="text" placeholder="free text"
+                       @bind="_remarks" @bind:event="oninput"
+                       class="bg-transparent border border-gray-500 focus:outline-none focus:bg-gray-700 p-0.5 flex-1 ml-2"/>
+            }
+        </div>
+    </div>
+
+    @* Encoded output *@
+    <div class="border border-slate-600 p-3 rounded flex flex-col gap-2">
+        <div class="flex items-center gap-2">
+            <div class="font-bold">Encoded</div>
+            <div class="ml-auto flex items-center gap-2">
+                @if (_copyStatus is not null)
+                {
+                    <span class="text-green-400">@_copyStatus</span>
+                }
+                <button type="button" @onclick="CopyEncoded"
+                        class="rounded bg-orange-900 transition-colors hover:bg-orange-800 p-1 px-2">
+                    Copy
+                </button>
+                <button type="button" @onclick="SaveDraftAsync"
+                        class="rounded bg-slate-700 transition-colors hover:bg-slate-600 p-1 px-2">
+                    Save draft
+                </button>
+                <button type="button" @onclick="ResetForm"
+                        class="rounded bg-slate-700 transition-colors hover:bg-slate-600 p-1 px-2">
+                    Reset
+                </button>
+            </div>
+        </div>
+        <pre class="font-mono bg-slate-900 p-2 rounded whitespace-pre-wrap break-all">@_encoded</pre>
+        @if (_errors.Count > 0)
+        {
+            <ul class="text-orange-600 list-disc list-inside">
+                @foreach (var e in _errors)
+                {
+                    <li>/@e.Field — @e.Message</li>
+                }
+            </ul>
+        }
+    </div>
+
+    @* Decode input *@
+    <div class="border border-slate-600 p-3 rounded flex flex-col gap-2">
+        <div class="font-bold">Decode</div>
+        <textarea rows="2" placeholder="Paste an encoded PIREP here"
+                  @bind="_decodeInput" @bind:event="oninput"
+                  class="font-mono bg-transparent border border-gray-500 focus:outline-none focus:bg-gray-700 p-1 w-full"></textarea>
+        <div class="flex items-center gap-2">
+            <button type="button" @onclick="DecodeInput"
+                    class="rounded bg-orange-900 transition-colors hover:bg-orange-800 p-1 px-2">
+                Decode into form
+            </button>
+            @if (_decodeStatus is not null)
+            {
+                <span class="text-gray-400">@_decodeStatus</span>
+            }
+        </div>
+        @if (_decodeWarnings.Count > 0)
+        {
+            <ul class="text-yellow-500 list-disc list-inside">
+                @foreach (var w in _decodeWarnings)
+                {
+                    <li>@(w.Field is null ? "" : $"/{w.Field} — ")@w.Message</li>
+                }
+            </ul>
+        }
+    </div>
+
+    @* Drafts *@
+    @if (_drafts.Count > 0)
+    {
+        <div class="border border-slate-600 p-3 rounded flex flex-col gap-2">
+            <div class="font-bold">Drafts (@_drafts.Count)</div>
+            @foreach (var d in _drafts)
+            {
+                <div class="flex items-center gap-2">
+                    <span class="text-gray-400 w-40">@d.SavedAt.ToLocalTime().ToString("yyyy-MM-dd HH:mm")</span>
+                    <span class="flex-1 font-mono">@d.Label</span>
+                    <button type="button" @onclick="@(() => LoadDraft(d))"
+                            class="rounded bg-orange-900 transition-colors hover:bg-orange-800 p-0.5 px-2">
+                        Load
+                    </button>
+                    <button type="button" @onclick="@(() => DeleteDraftAsync(d.Id))"
+                            class="rounded bg-slate-700 transition-colors hover:bg-slate-600 p-0.5 px-2">
+                        Delete
+                    </button>
+                </div>
+            }
+        </div>
+    }
+
+</div>
+
+@code {
+    // ---------- form state ----------
+    private ReportType _reportType = ReportType.Routine;
+    private string _saIdentifier = "";
+
+    private record SegmentEditor(string Fix, string RadialDistance);
+
+    private List<SegmentEditor> _locationSegments = [new SegmentEditor("", "")];
+
+    private string _time = "";
+
+    private string _flightLevelInput = "";
+    private bool _flightLevelUnknown;
+
+    private string _aircraftTypeInput = "";
+    private bool _aircraftTypeUnknown;
+
+    // Sky
+    private bool _includeSky;
+    private SectionMode _skyMode = SectionMode.Structured;
+    private string _skyRaw = "";
+    private sealed class SkyLayerEditor
+    {
+        public string Base { get; set; } = "";
+        public SkyCover Cover { get; set; } = SkyCover.SKC;
+        public string Tops { get; set; } = "";
+    }
+    private List<SkyLayerEditor> _skyLayers = [new SkyLayerEditor()];
+
+    // Weather
+    private bool _includeWeather;
+    private SectionMode _weatherMode = SectionMode.Structured;
+    private string _weatherRaw = "";
+    private int? _weatherVisibility;
+    private string _weatherContractions = "";
+
+    // Temperature
+    private bool _includeTemp;
+    private int? _tempC;
+
+    // Wind
+    private bool _includeWind;
+    private int? _windDir;
+    private int? _windSpd;
+
+    // Turbulence
+    private bool _includeTurbulence;
+    private SectionMode _turbulenceMode = SectionMode.Structured;
+    private string _turbulenceRaw = "";
+    private TurbulenceIntensity _turbIntensity = TurbulenceIntensity.LGT;
+    private TurbulenceType _turbType = TurbulenceType.None;
+    private string _turbBand = "";
+
+    // Icing
+    private bool _includeIcing;
+    private SectionMode _icingMode = SectionMode.Structured;
+    private string _icingRaw = "";
+    private IcingIntensity _icingIntensity = IcingIntensity.LGT;
+    private IcingType _icingType = IcingType.None;
+    private string _icingBand = "";
+
+    // Remarks
+    private bool _includeRemarks;
+    private string _remarks = "";
+
+    // Decode
+    private string _decodeInput = "";
+    private string? _decodeStatus;
+    private List<ParseWarning> _decodeWarnings = [];
+
+    // Persistent state
+    private bool _showSettings;
+    private string _settingsSaId = "";
+    private bool _settingsPrefix = true;
+    private string _settingsDefaultAircraft = "";
+    private List<DraftEntry> _drafts = [];
+
+    // JS + transient UI
+    private IJSObjectReference? _storage;
+    private string? _copyStatus;
+    private CancellationTokenSource? _copyCts;
+
+    private enum SectionMode { Structured, Raw }
+
+    // ---------- computed ----------
+    private string _encoded => PirepFormatter.Format(BuildPirep(), BuildPirepSettings());
+
+    private IReadOnlyList<ValidationError> _errors => PirepValidator.Validate(BuildPirep());
+
+    private PirepSettings BuildPirepSettings() => new()
+    {
+        DefaultSaIdentifier = string.IsNullOrWhiteSpace(_settingsSaId) ? null : _settingsSaId.Trim().ToUpperInvariant(),
+        PrefixWithSaIdentifier = _settingsPrefix,
+        DefaultAircraftType = string.IsNullOrWhiteSpace(_settingsDefaultAircraft) ? null : _settingsDefaultAircraft.Trim().ToUpperInvariant(),
+    };
+
+    private PirepRecord BuildPirep()
+    {
+        var segments = _locationSegments
+            .Where(s => !string.IsNullOrWhiteSpace(s.Fix))
+            .Select(s => new LocationSegment
+            {
+                Fix = s.Fix.Trim().ToUpperInvariant(),
+                RadialDistance = string.IsNullOrWhiteSpace(s.RadialDistance) ? null : s.RadialDistance.Trim(),
+            })
+            .ToList();
+
+        var flightLevel = _flightLevelUnknown ? "UNKN" : (_flightLevelInput?.Trim().ToUpperInvariant() ?? "");
+        var aircraftType = _aircraftTypeUnknown
+            ? "UNKN"
+            : (string.IsNullOrWhiteSpace(_aircraftTypeInput)
+                ? (_settingsDefaultAircraft?.Trim().ToUpperInvariant() ?? "")
+                : _aircraftTypeInput.Trim().ToUpperInvariant());
+
+        var pirep = new PirepRecord
+        {
+            SaIdentifier = string.IsNullOrWhiteSpace(_saIdentifier) ? null : _saIdentifier.Trim().ToUpperInvariant(),
+            ReportType = _reportType,
+            Location = new Location { Segments = segments },
+            Time = _time?.Trim() ?? "",
+            FlightLevel = string.IsNullOrWhiteSpace(flightLevel) ? "UNKN" : flightLevel,
+            AircraftType = string.IsNullOrWhiteSpace(aircraftType) ? "UNKN" : aircraftType,
+        };
+
+        if (_includeSky)
+        {
+            if (_skyMode == SectionMode.Raw)
+            {
+                pirep = pirep with { SkyCoverRaw = string.IsNullOrWhiteSpace(_skyRaw) ? null : _skyRaw.Trim() };
+            }
+            else
+            {
+                var layers = _skyLayers
+                    .Where(l => !string.IsNullOrWhiteSpace(l.Base))
+                    .Select(l => new CloudLayer
+                    {
+                        Base = l.Base.Trim().ToUpperInvariant(),
+                        Cover = l.Cover,
+                        Tops = string.IsNullOrWhiteSpace(l.Tops) ? null : l.Tops.Trim().ToUpperInvariant(),
+                    })
+                    .ToList();
+                if (layers.Count > 0)
+                {
+                    pirep = pirep with { SkyCover = layers };
+                }
+            }
+        }
+
+        if (_includeWeather)
+        {
+            if (_weatherMode == SectionMode.Raw)
+            {
+                pirep = pirep with { WeatherRaw = string.IsNullOrWhiteSpace(_weatherRaw) ? null : _weatherRaw.Trim() };
+            }
+            else
+            {
+                var contractions = (_weatherContractions ?? "")
+                    .Split(' ', StringSplitOptions.RemoveEmptyEntries)
+                    .Select(c => c.ToUpperInvariant())
+                    .ToList();
+                pirep = pirep with
+                {
+                    Weather = new Weather
+                    {
+                        FlightVisibilitySm = _weatherVisibility,
+                        Contractions = contractions,
+                    },
+                };
+            }
+        }
+
+        if (_includeTemp && _tempC is int t) pirep = pirep with { TemperatureC = t };
+        if (_includeWind) pirep = pirep with { WindDirection = _windDir, WindSpeedKt = _windSpd };
+
+        if (_includeTurbulence)
+        {
+            if (_turbulenceMode == SectionMode.Raw)
+            {
+                pirep = pirep with { TurbulenceRaw = string.IsNullOrWhiteSpace(_turbulenceRaw) ? null : _turbulenceRaw.Trim() };
+            }
+            else
+            {
+                pirep = pirep with
+                {
+                    Turbulence = new Turbulence
+                    {
+                        Intensity = _turbIntensity,
+                        Type = _turbType,
+                        AltitudeBand = string.IsNullOrWhiteSpace(_turbBand) ? null : _turbBand.Trim(),
+                    },
+                };
+            }
+        }
+
+        if (_includeIcing)
+        {
+            if (_icingMode == SectionMode.Raw)
+            {
+                pirep = pirep with { IcingRaw = string.IsNullOrWhiteSpace(_icingRaw) ? null : _icingRaw.Trim() };
+            }
+            else
+            {
+                pirep = pirep with
+                {
+                    Icing = new Icing
+                    {
+                        Intensity = _icingIntensity,
+                        Type = _icingType,
+                        AltitudeBand = string.IsNullOrWhiteSpace(_icingBand) ? null : _icingBand.Trim(),
+                    },
+                };
+            }
+        }
+
+        if (_includeRemarks && !string.IsNullOrWhiteSpace(_remarks))
+        {
+            pirep = pirep with { Remarks = _remarks.Trim() };
+        }
+
+        return pirep;
+    }
+
+    // ---------- event handlers ----------
+    private void SetReportType(ReportType rt) => _reportType = rt;
+
+    private void AddLocationSegment() => _locationSegments.Add(new SegmentEditor("", ""));
+
+    private void RemoveLocationSegment(int idx)
+    {
+        if (idx >= 0 && idx < _locationSegments.Count && _locationSegments.Count > 1)
+        {
+            _locationSegments.RemoveAt(idx);
+        }
+    }
+
+    private void UpdateSegmentFix(int idx, string value)
+    {
+        _locationSegments[idx] = _locationSegments[idx] with { Fix = value.ToUpperInvariant() };
+    }
+
+    private void UpdateSegmentRadial(int idx, string value)
+    {
+        _locationSegments[idx] = _locationSegments[idx] with { RadialDistance = value };
+    }
+
+    private void FillTimeNow() => _time = DateTime.UtcNow.ToString("HHmm", CultureInfo.InvariantCulture);
+
+    private RenderFragment RenderModeToggle(SectionMode current, Action<SectionMode> set) => builder =>
+    {
+        builder.OpenElement(0, "div");
+        builder.AddAttribute(1, "class", "inline-flex border border-slate-600 rounded text-xs");
+        var seq = 2;
+        foreach (var mode in new[] { SectionMode.Structured, SectionMode.Raw })
+        {
+            var isActive = current == mode;
+            var capturedMode = mode;
+            builder.OpenElement(seq++, "button");
+            builder.AddAttribute(seq++, "type", "button");
+            builder.AddAttribute(seq++, "class",
+                "px-2 py-0.5 " + (isActive ? "bg-orange-900" : "bg-slate-800 hover:bg-slate-700"));
+            builder.AddAttribute(seq++, "onclick",
+                EventCallback.Factory.Create(this, () => set(capturedMode)));
+            builder.AddContent(seq++, capturedMode == SectionMode.Structured ? "Structured" : "Raw");
+            builder.CloseElement();
+        }
+        builder.CloseElement();
+    };
+
+    // ---------- copy ----------
+    private async Task CopyEncoded()
+    {
+        await Js.InvokeVoidAsync("CopyToClipboard", _encoded);
+        _copyStatus = "Copied!";
+        _copyCts?.Cancel();
+        _copyCts = new CancellationTokenSource();
+        var token = _copyCts.Token;
+        _ = Task.Run(async () =>
+        {
+            try { await Task.Delay(1500, token); }
+            catch (TaskCanceledException) { return; }
+            if (token.IsCancellationRequested) return;
+            _copyStatus = null;
+            await InvokeAsync(StateHasChanged);
+        });
+    }
+
+    // ---------- decode ----------
+    private void DecodeInput()
+    {
+        var result = PirepParser.Parse(_decodeInput ?? "");
+        _decodeWarnings = result.Warnings.ToList();
+        LoadFromPirep(result.Pirep);
+        _decodeStatus = _decodeWarnings.Count == 0
+            ? "Decoded."
+            : $"Decoded with {_decodeWarnings.Count} warning(s).";
+    }
+
+    private void LoadFromPirep(PirepRecord p)
+    {
+        _reportType = p.ReportType;
+        _saIdentifier = p.SaIdentifier ?? "";
+
+        _locationSegments = p.Location.Segments.Count == 0
+            ? [new SegmentEditor("", "")]
+            : p.Location.Segments
+                .Select(s => new SegmentEditor(s.Fix, s.RadialDistance ?? ""))
+                .ToList();
+
+        _time = p.Time;
+        _flightLevelUnknown = p.FlightLevel == "UNKN";
+        _flightLevelInput = _flightLevelUnknown ? "" : p.FlightLevel;
+        _aircraftTypeUnknown = p.AircraftType == "UNKN";
+        _aircraftTypeInput = _aircraftTypeUnknown ? "" : p.AircraftType;
+
+        // Sky
+        _includeSky = p.SkyCover is { Count: > 0 } || !string.IsNullOrWhiteSpace(p.SkyCoverRaw);
+        if (p.SkyCover is { Count: > 0 } skyLayers)
+        {
+            _skyLayers = skyLayers.Select(l => new SkyLayerEditor
+            {
+                Base = l.Base,
+                Cover = l.Cover,
+                Tops = l.Tops ?? "",
+            }).ToList();
+            _skyMode = SectionMode.Structured;
+        }
+        else if (!string.IsNullOrWhiteSpace(p.SkyCoverRaw))
+        {
+            _skyMode = SectionMode.Raw;
+            _skyLayers = [new SkyLayerEditor()];
+        }
+        _skyRaw = p.SkyCoverRaw ?? "";
+
+        // Weather
+        _includeWeather = p.Weather is not null || !string.IsNullOrWhiteSpace(p.WeatherRaw);
+        if (p.Weather is not null)
+        {
+            _weatherVisibility = p.Weather.FlightVisibilitySm;
+            _weatherContractions = string.Join(' ', p.Weather.Contractions);
+            _weatherMode = SectionMode.Structured;
+        }
+        else
+        {
+            _weatherVisibility = null;
+            _weatherContractions = "";
+            if (!string.IsNullOrWhiteSpace(p.WeatherRaw))
+            {
+                _weatherMode = SectionMode.Raw;
+            }
+        }
+        _weatherRaw = p.WeatherRaw ?? "";
+
+        _includeTemp = p.TemperatureC is not null;
+        _tempC = p.TemperatureC;
+
+        _includeWind = p.WindDirection is not null || p.WindSpeedKt is not null;
+        _windDir = p.WindDirection;
+        _windSpd = p.WindSpeedKt;
+
+        // Turbulence
+        _includeTurbulence = p.Turbulence is not null || !string.IsNullOrWhiteSpace(p.TurbulenceRaw);
+        if (p.Turbulence is not null)
+        {
+            _turbIntensity = p.Turbulence.Intensity;
+            _turbType = p.Turbulence.Type;
+            _turbBand = p.Turbulence.AltitudeBand ?? "";
+            _turbulenceMode = SectionMode.Structured;
+        }
+        else if (!string.IsNullOrWhiteSpace(p.TurbulenceRaw))
+        {
+            _turbulenceMode = SectionMode.Raw;
+        }
+        _turbulenceRaw = p.TurbulenceRaw ?? "";
+
+        // Icing
+        _includeIcing = p.Icing is not null || !string.IsNullOrWhiteSpace(p.IcingRaw);
+        if (p.Icing is not null)
+        {
+            _icingIntensity = p.Icing.Intensity;
+            _icingType = p.Icing.Type;
+            _icingBand = p.Icing.AltitudeBand ?? "";
+            _icingMode = SectionMode.Structured;
+        }
+        else if (!string.IsNullOrWhiteSpace(p.IcingRaw))
+        {
+            _icingMode = SectionMode.Raw;
+        }
+        _icingRaw = p.IcingRaw ?? "";
+
+        _includeRemarks = !string.IsNullOrWhiteSpace(p.Remarks);
+        _remarks = p.Remarks ?? "";
+    }
+
+    private void ResetForm()
+    {
+        _reportType = ReportType.Routine;
+        _saIdentifier = "";
+        _locationSegments = [new SegmentEditor("", "")];
+        _time = "";
+        _flightLevelInput = "";
+        _flightLevelUnknown = false;
+        _aircraftTypeInput = "";
+        _aircraftTypeUnknown = false;
+        _includeSky = _includeWeather = _includeTemp = _includeWind =
+            _includeTurbulence = _includeIcing = _includeRemarks = false;
+        _skyMode = _weatherMode = _turbulenceMode = _icingMode = SectionMode.Structured;
+        _skyRaw = _weatherRaw = _turbulenceRaw = _icingRaw = "";
+        _skyLayers = [new SkyLayerEditor()];
+        _weatherVisibility = null;
+        _weatherContractions = "";
+        _tempC = null;
+        _windDir = _windSpd = null;
+        _turbIntensity = TurbulenceIntensity.LGT;
+        _turbType = TurbulenceType.None;
+        _turbBand = "";
+        _icingIntensity = IcingIntensity.LGT;
+        _icingType = IcingType.None;
+        _icingBand = "";
+        _remarks = "";
+        _decodeInput = "";
+        _decodeStatus = null;
+        _decodeWarnings = [];
+    }
+
+    // ---------- drafts (localStorage) ----------
+    private const int MaxDrafts = 50;
+
+    private async Task SaveDraftAsync()
+    {
+        if (_storage is null) return;
+        var pirep = BuildPirep();
+        var entry = new DraftEntry
+        {
+            Pirep = pirep,
+            Label = AutoLabel(pirep),
+        };
+        _drafts.Insert(0, entry);
+        if (_drafts.Count > MaxDrafts) _drafts = _drafts.Take(MaxDrafts).ToList();
+        await _storage.InvokeVoidAsync("set", "pirepDrafts", _drafts);
+    }
+
+    private async Task DeleteDraftAsync(string id)
+    {
+        _drafts = _drafts.Where(d => d.Id != id).ToList();
+        if (_storage is not null)
+        {
+            await _storage.InvokeVoidAsync("set", "pirepDrafts", _drafts);
+        }
+    }
+
+    private void LoadDraft(DraftEntry d) => LoadFromPirep(d.Pirep);
+
+    private static string AutoLabel(PirepRecord pirep)
+    {
+        var fix = pirep.Location.Segments.FirstOrDefault()?.Fix ?? "----";
+        var time = string.IsNullOrWhiteSpace(pirep.Time) ? "----" : pirep.Time;
+        var said = string.IsNullOrWhiteSpace(pirep.SaIdentifier) ? "" : pirep.SaIdentifier + " ";
+        return $"{said}{time} {fix}".Trim();
+    }
+
+    // ---------- settings (localStorage) ----------
+    private sealed record PersistedSettings
+    {
+        public string SaId { get; init; } = "";
+        public bool Prefix { get; init; } = true;
+        public string DefaultAircraft { get; init; } = "";
+    }
+
+    private async Task PersistSettings()
+    {
+        if (_storage is null) return;
+        await _storage.InvokeVoidAsync("set", "pirepSettings", new PersistedSettings
+        {
+            SaId = _settingsSaId,
+            Prefix = _settingsPrefix,
+            DefaultAircraft = _settingsDefaultAircraft,
+        });
+    }
+
+    // ---------- lifecycle ----------
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!firstRender) return;
+        _storage = await Js.InvokeAsync<IJSObjectReference>("import", "./scripts/storage.js");
+
+        var saved = await _storage.InvokeAsync<PersistedSettings?>("get", "pirepSettings");
+        if (saved is not null)
+        {
+            _settingsSaId = saved.SaId ?? "";
+            _settingsPrefix = saved.Prefix;
+            _settingsDefaultAircraft = saved.DefaultAircraft ?? "";
+        }
+
+        var drafts = await _storage.InvokeAsync<List<DraftEntry>?>("get", "pirepDrafts");
+        if (drafts is not null) _drafts = drafts;
+
+        StateHasChanged();
+    }
+}


### PR DESCRIPTION
## Summary
- New `/pirep` tab encodes and decodes FAA PIREPs (Form 7110-2), ported from the standalone Avalonia app at `X:/dev/pirep-encoder`
- Domain logic (parser, formatter, validator, models) copied verbatim into `Features/PirepEncoder/`; filesystem-based draft/settings storage replaced by browser `localStorage` via existing `storage.js`
- Single stacked layout matches the app's dark-slate / orange-accent Tailwind style; composite sections (Sky, Weather, Turbulence, Icing) each expose a Structured/Raw mode toggle for desktop parity
- Includes drafts (save / load / delete, capped at 50), settings defaults (SA id, prefix toggle, default aircraft), "Now" button for time, and copy-to-clipboard with transient feedback

## Test plan
- [ ] `dotnet build` — zero errors, no new warnings from `Features/PirepEncoder/`
- [ ] Navigate to `/pirep` — page renders with UA/UUA radios, required fields card, optional sections, encoded output panel, and decode input
- [ ] Fill fix `RFD` radial `170030`, time `1315`, FL `160`, TP `PA60`, sky `025 OVC 095` + `180 OVC`, TA `-21`, WV `270048` — verify encoded output is exactly `UA /OV RFD 170030/TM 1315/FL160/TP PA60 /SK 025 OVC 095/180 OVC/TA -21/WV 270048`
- [ ] Paste that string into the decode box, click Decode, confirm the form repopulates and re-encodes to the identical string
- [ ] Save a draft, reload the page, confirm the draft persists and Load restores the form
- [ ] Open Settings, set SA id + toggle prefix on, confirm the encoded string prepends the SA id
- [ ] Toggle a composite section between Structured and Raw, confirm state survives the switch
- [ ] Enter a 2-letter fix and confirm the inline validation error appears; enter time `2599` and confirm the clock-range error appears
- [ ] Click Copy, paste elsewhere, confirm the encoded string is on the clipboard