### PR TITLE
feat: add VOR lookup panel to /codes page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -399,3 +399,9 @@ FodyWeavers.xsd
 # JetBrains Rider
 *.sln.iml
 *.idea
+
+# Claude Code MCP server config (per-developer)
+.mcp.json
+
+# Playwright MCP screenshots and traces
+.playwright-mcp/

--- a/Features/IcaoReference/UI/Pages/Codes.razor
+++ b/Features/IcaoReference/UI/Pages/Codes.razor
@@ -1,11 +1,14 @@
 ﻿@page "/codes"
 @using ZoaReference.Features.IcaoReference.Models
 @using ZoaReference.Features.IcaoReference.Repositories
+@using ZoaReference.Features.Nasr.Models
+@using ZoaReference.Features.Nasr.Services
 @rendermode InteractiveServer
 
 @inject AirlineRepository Airlines
 @inject AirportRepository Airports
 @inject AircraftTypeRepository AircraftTypes
+@inject NasrDataService NasrData
 
 @using Microsoft.Extensions.Options
 @inject IOptions<AppSettings> Settings
@@ -94,6 +97,31 @@
             <PropertyColumn Property="@(p => p.LandAndHoldShortGroup)" Title="LAHSO" Sortable="true"/>
         </QuickGrid>
     </div>
+
+    <div>
+        <EditForm Model="@_vorForm" OnValidSubmit="@VorSubmit">
+            <DataAnnotationsValidator/>
+            <InputText @bind-Value="_vorForm!.Search"
+                       class="uppercase bg-transparent border border-gray-500 focus:outline-none focus:bg-gray-700 p-0.5 mb-2 ml-1 w-64"
+                       placeholder="VOR code / name"/>
+            <button type="submit" class="rounded bg-orange-900 transition-colors hover:bg-orange-800 p-1 ml-3">Search
+                VORs
+            </button>
+            <ValidationMessage For="() => _vorForm.Search"/>
+        </EditForm>
+
+        <QuickGrid Items="@_displayedVors.AsQueryable()">
+            <PropertyColumn Property="@(p => p.Id)" Title="Code" Sortable="true"/>
+            <PropertyColumn Property="@(p => p.Name)" Title="Name" Sortable="true"/>
+            <TemplateColumn TGridItem="NavaidInfo" Title="Location" Sortable="true" SortBy="@_locationSort">
+                @($"{context.City}, {context.State}")
+            </TemplateColumn>
+            <PropertyColumn Property="@(p => p.Frequency)" Title="Frequency" Sortable="true"/>
+            <TemplateColumn TGridItem="NavaidInfo" Title="Coordinates">
+                @($"{context.Latitude:F4}, {context.Longitude:F4}")
+            </TemplateColumn>
+        </QuickGrid>
+    </div>
 </div>
 
 
@@ -102,10 +130,15 @@
     private readonly AirlineForm? _airlineForm = new();
     private readonly AirportForm? _airportForm = new();
     private readonly AircraftForm? _aircraftForm = new();
+    private readonly VorForm? _vorForm = new();
 
     private IEnumerable<Airline> _displayedAirlines = Enumerable.Empty<Airline>();
     private IEnumerable<Airport> _displayedAirports = Enumerable.Empty<Airport>();
     private IEnumerable<AircraftType> _displayedAircraft = Enumerable.Empty<AircraftType>();
+    private IEnumerable<NavaidInfo> _displayedVors = Enumerable.Empty<NavaidInfo>();
+
+    private readonly GridSort<NavaidInfo> _locationSort =
+        GridSort<NavaidInfo>.ByAscending(n => n.State).ThenAscending(n => n.City);
 
     private class AirlineForm
     {
@@ -182,6 +215,16 @@
 
         var trimmed = _aircraftForm.Search.Trim();
         _displayedAircraft = AircraftTypes.AllAircraftTypes.Where(a => TypeDesignatorPredicate(trimmed, a) || ManufacturerPredicate(trimmed, a) || ModelPredicate(trimmed, a));
+    }
+
+    private class VorForm
+    {
+        [Required] public string Search { get; set; } = "";
+    }
+
+    private async Task VorSubmit()
+    {
+        _displayedVors = await NasrData.SearchVors(_vorForm!.Search);
     }
 
 }

--- a/Features/Nasr/Models/NavaidInfo.cs
+++ b/Features/Nasr/Models/NavaidInfo.cs
@@ -7,4 +7,6 @@ public record NavaidInfo(
     string Frequency,
     double Latitude,
     double Longitude,
-    string Variation);
+    string Variation,
+    string City,
+    string State);

--- a/Features/Nasr/Services/NasrDataService.cs
+++ b/Features/Nasr/Services/NasrDataService.cs
@@ -15,6 +15,8 @@ public partial class NasrDataService(
     private const string AwyRestrCacheKey = "NasrAirwayRestrictions";
     private const string WaypointCacheKey = "NasrWaypoints";
 
+    private static readonly string[] VorFamilyTypes = ["VOR", "VOR/DME", "VORTAC"];
+
     public async Task<IReadOnlyList<NavaidInfo>> SearchNavaids(string query, CancellationToken ct = default)
     {
         var navaids = await GetNavaids(ct);
@@ -24,6 +26,18 @@ public partial class NasrDataService(
                 n.Id.Contains(q, StringComparison.OrdinalIgnoreCase) ||
                 n.Name.Contains(q, StringComparison.OrdinalIgnoreCase) ||
                 n.Type.Contains(q, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+    }
+
+    public async Task<IReadOnlyList<NavaidInfo>> SearchVors(string query, CancellationToken ct = default)
+    {
+        var navaids = await GetNavaids(ct);
+        var q = query.Trim();
+        return navaids
+            .Where(n => VorFamilyTypes.Contains(n.Type))
+            .Where(n =>
+                n.Id.Contains(q, StringComparison.OrdinalIgnoreCase) ||
+                n.Name.Contains(q, StringComparison.OrdinalIgnoreCase))
             .ToList();
     }
 

--- a/Features/Nasr/Services/NasrParser.cs
+++ b/Features/Nasr/Services/NasrParser.cs
@@ -23,6 +23,8 @@ public static class NasrParser
             var type = SafeSubstring(line, 8, 20).Trim();
             var id = SafeSubstring(line, 28, 4).Trim();
             var name = SafeSubstring(line, 42, 30).Trim();
+            var city = SafeSubstring(line, 72, 40).Trim();
+            var state = SafeSubstring(line, 142, 2).Trim();
 
             // Latitude: formatted seconds at position 371, length 14
             var latStr = SafeSubstring(line, 371, 14).Trim();
@@ -35,7 +37,7 @@ public static class NasrParser
 
             if (string.IsNullOrEmpty(id)) continue;
 
-            navaids.Add(new NavaidInfo(id, name, type, frequency, lat, lon, variation));
+            navaids.Add(new NavaidInfo(id, name, type, frequency, lat, lon, variation, city, state));
         }
 
         return navaids;


### PR DESCRIPTION
## Summary

Adds a fourth search panel on the Codes page for looking up VOR-family navaids (VOR, VOR/DME, VORTAC) by code or name. Results show Code, Name, Location (City, State), Frequency, and Coordinates in a sortable QuickGrid.

Mirrors the existing airline/airport/aircraft panels — `EditForm` with a search input + submit button, `QuickGrid` for results, submit-on-enter, no debounce.

## Changes

- **`NavaidInfo`** — new `City` and `State` fields.
- **`NasrParser.ParseNavaids`** — extract City (offset 72, len 40) and State postal code (offset 142, len 2) from NAV1 records. Offsets verified against a real NAV.txt record from the current AIRAC cycle.
- **`NasrDataService.SearchVors`** — filters cached navaids to VOR-family types and matches on `Id` or `Name` only (unlike the general `SearchNavaids` used by the terminal command, which also matches `Type`).
- **`Codes.razor`** — inject `NasrDataService`, add `VorForm` + async `VorSubmit` handler, and an `EditForm` + `QuickGrid` block with `TemplateColumn`s for the composite Location (City, State) and Coordinates cells. Location column sorts by State then City.
- **`.gitignore`** — add `.mcp.json` and `.playwright-mcp/`.

## Test plan

- [x] `dotnet build` — 0 errors, no new warnings
- [x] Page renders at http://localhost:5063/codes with the fourth panel visible below Aircraft
- [x] Search `SFO` → `SFO · SAN FRANCISCO · SAN FRANCISCO, CA · 115.80 · 37.6195, -122.3739`
- [x] Search `OAK` → `OAK · OAKLAND · OAKLAND, CA · 116.80 · 37.7259, -122.2236`
- [x] Search `LAS VEGAS` → `LAS · LAS VEGAS · LAS VEGAS, NV · 116.90 · 36.0797, -115.1598`
- [x] All column headers sort ascending/descending when clicked; Location sorts by State then City

🤖 Generated with [Claude Code](https://claude.com/claude-code)