### PR TITLE
Wrap header nav on narrow widths

### DIFF
--- a/Components/Layout/NavMenu.razor
+++ b/Components/Layout/NavMenu.razor
@@ -5,21 +5,23 @@
 @inject IJSRuntime Js
 
 <div class="bg-slate-950 shadow-lg sticky left-0 top-0 z-40 flex items-center text-gray-400 border-b border-slate-700">
-    <div>
-        <LiveTime/>
-    </div>
     <nav class="flex items-center flex-1 min-w-0">
-        <ul @ref="_ulRef" class="flex list-none items-center p-1">
+        <ul @ref="_ulRef" class="flex flex-wrap list-none items-center p-1">
+            <li>
+                <LiveTime/>
+            </li>
             @foreach (var key in _orderedKeys)
             {
                 var item = NavItems.All[key];
                 <NavButton @key="key" Key="@key" href="@item.Href">@item.Label</NavButton>
             }
+            <li>
+                <button @onclick="ToggleReorderMode"
+                        class="mx-1.5 text-xs whitespace-nowrap px-2 py-1 rounded transition-colors @(_reorderMode ? "bg-orange-700 text-gray-100" : "text-gray-500 hover:text-gray-300")">
+                    @(_reorderMode ? "Done" : "Reorder")
+                </button>
+            </li>
         </ul>
-        <button @onclick="ToggleReorderMode"
-                class="ml-auto mr-2 text-xs whitespace-nowrap px-2 py-1 rounded transition-colors @(_reorderMode ? "bg-orange-700 text-gray-100" : "text-gray-500 hover:text-gray-300")">
-            @(_reorderMode ? "Done" : "Reorder")
-        </button>
     </nav>
 </div>
 


### PR DESCRIPTION
## Summary
- Header nav now wraps onto additional rows instead of forcing horizontal scroll on narrow windows.
- LiveTime and the Reorder toggle flow inline with the nav buttons (previously a pinned left column and right-aligned button).

## Test plan
- [x] Verified at 1400px: single row, everything inline.
- [x] Verified at 600px: 3 rows wrap cleanly, no horizontal scroll on the header.
- [x] Verified at 375px: header wraps fully with no horizontal scroll on the bar.
- [ ] Confirm drag-to-reorder still works (LiveTime/Reorder li have no `data-nav-key`, so the JS filter ignores them).